### PR TITLE
Fixes issue #55 - EncodingScheme is serializable

### DIFF
--- a/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/parameter/DefaultEncodingScheme.java
+++ b/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/parameter/DefaultEncodingScheme.java
@@ -25,6 +25,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import javolution.xml.XMLSerializable;
 import org.mobicents.protocols.ss7.sccp.message.ParseException;
 import org.mobicents.protocols.ss7.sccp.parameter.EncodingScheme;
 import org.mobicents.protocols.ss7.sccp.parameter.EncodingSchemeType;
@@ -33,7 +34,7 @@ import org.mobicents.protocols.ss7.sccp.parameter.EncodingSchemeType;
  * Default impl which supports simple encoding.
  * @author baranowb
  */
-public class DefaultEncodingScheme implements EncodingScheme {
+public class DefaultEncodingScheme implements EncodingScheme, XMLSerializable {
     public static final EncodingScheme INSTANCE = new DefaultEncodingScheme();
     public static final int SCHEMA_CODE = 0;
     public DefaultEncodingScheme() {


### PR DESCRIPTION
Issue #55 fixed by: https://github.com/gfigiel/jss7/commit/ce6df663eacee00fd9a01db5621e0cac353c2ce1

Tested succesfully by scenario: storring/getting SccpAddress type CMP field.