### PR TITLE
Fixes issue #58 - Add String digits support for GenericDigits

### DIFF
--- a/isup/isup-api/src/main/java/org/mobicents/protocols/ss7/isup/message/parameter/GenericDigits.java
+++ b/isup/isup-api/src/main/java/org/mobicents/protocols/ss7/isup/message/parameter/GenericDigits.java
@@ -83,6 +83,7 @@ public interface GenericDigits extends ISUPParameter {
 
     void setEncodedDigits(byte[] digits);
 
-    // TODO: add public String getDecodedDigits() ;
-    // TODO: add public void setDecodedDigits(int encodingScheme, String digits) ;
+    String getDecodedDigits() ;
+
+    void setDecodedDigits(int encodingScheme, String digits) ;
 }

--- a/isup/isup-api/src/main/java/org/mobicents/protocols/ss7/isup/message/parameter/GenericDigits.java
+++ b/isup/isup-api/src/main/java/org/mobicents/protocols/ss7/isup/message/parameter/GenericDigits.java
@@ -22,6 +22,8 @@
 
 package org.mobicents.protocols.ss7.isup.message.parameter;
 
+import java.io.UnsupportedEncodingException;
+
 /**
  * Start time:12:37:11 2009-07-23<br>
  * Project: mobicents-isup-stack<br>
@@ -83,7 +85,7 @@ public interface GenericDigits extends ISUPParameter {
 
     void setEncodedDigits(byte[] digits);
 
-    String getDecodedDigits() ;
+    String getDecodedDigits() throws UnsupportedEncodingException;
 
-    void setDecodedDigits(int encodingScheme, String digits) ;
+    void setDecodedDigits(int encodingScheme, String digits) throws UnsupportedEncodingException;
 }

--- a/isup/isup-impl/src/main/java/org/mobicents/protocols/ss7/isup/impl/message/parameter/GenericDigitsImpl.java
+++ b/isup/isup-impl/src/main/java/org/mobicents/protocols/ss7/isup/impl/message/parameter/GenericDigitsImpl.java
@@ -22,19 +22,20 @@
 
 package org.mobicents.protocols.ss7.isup.impl.message.parameter;
 
-import javax.xml.bind.DatatypeConverter;
-
 import javolution.xml.XMLFormat;
 import javolution.xml.stream.XMLStreamException;
-
 import org.mobicents.protocols.ss7.isup.ParameterException;
 import org.mobicents.protocols.ss7.isup.message.parameter.GenericDigits;
+import org.mobicents.protocols.ss7.isup.util.BcdHelper;
+
+import javax.xml.bind.DatatypeConverter;
 
 /**
  * Start time:12:24:47 2009-03-31<br>
  * Project: mobicents-isup-stack<br>
  *
  * @author <a href="mailto:baranowb@gmail.com"> Bartosz Baranowski </a>
+ * @author <a href="mailto:grzegorz.figiel@pro-ids.com"> Grzegorz Figiel </a>
  */
 public class GenericDigitsImpl extends AbstractISUPParameter implements GenericDigits {
 
@@ -60,14 +61,32 @@ public class GenericDigitsImpl extends AbstractISUPParameter implements GenericD
         this.setEncodedDigits(digits);
     }
 
+    public GenericDigitsImpl(int encodingScheme, int typeOfDigits, String digits) {
+        super();
+        this.encodingScheme = encodingScheme;
+        this.typeOfDigits = typeOfDigits;
+        this.setEncodedDigits(BcdHelper.stringToBCD(digits));
+    }
+
     public GenericDigitsImpl() {
         super();
 
     }
 
-    // TODO: add method: public String getDecodedDigits() ;
-    // TODO: add method: public void setDecodedDigits(int encodingScheme, String digits) ;
-    // TODO: add constructor: public GenericDigitsImpl(int encodingScheme, int typeOfDigits, String digits)
+    public String getDecodedDigits() {
+        boolean isOdd = this.encodingScheme == GenericDigits._ENCODING_SCHEME_BCD_ODD ? true : false;
+        String result = BcdHelper.bcdToString(isOdd, digits);
+        return result;
+    }
+
+    public void setDecodedDigits(int encodingScheme, String digits) {
+        if (digits == null || digits.length() < 1) {
+            throw new IllegalArgumentException("Digits must not be null");
+        }
+        //TODO: analyse if encoding scheme is correctly set (ODD/EVEN) vs number of digits
+        this.encodingScheme = encodingScheme;
+        this.setEncodedDigits(BcdHelper.stringToBCD(digits));
+    }
 
     public int decode(byte[] b) throws ParameterException {
         if (b == null || b.length < 2) {

--- a/isup/isup-impl/src/main/java/org/mobicents/protocols/ss7/isup/util/BcdHelper.java
+++ b/isup/isup-impl/src/main/java/org/mobicents/protocols/ss7/isup/util/BcdHelper.java
@@ -1,0 +1,119 @@
+/**
+ *  Copyright 2016 Grzegorz Figiel
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package org.mobicents.protocols.ss7.isup.util;
+
+/**
+ * Modification of the BCD Conversion in java (BCD.java Source Copyright 2010 Firat Salgur) as to:
+ * <ul>
+ * <li>change nibbles order in BCD encoded bytes table.</li>
+ * <li>add String digits support</li>
+ * <li>add support for ODD and EVEN digits number</li>
+ * </ul>
+ * @see <a href="https://gist.github.com/neuro-sys/953548">https://gist.github.com/neuro-sys/953548</a>
+ *
+ * @author <a href="mailto:grzegorz.figiel@pro-ids.com"> Grzegorz Figiel (ProIDS sp. z o.o.)</a>
+ */
+public class BcdHelper {
+
+    public static byte[] stringToBCD(String bcdString) {
+        long num = Long.parseLong(bcdString);
+        return decimalToBCD(num);
+    }
+
+    public static String getBinString(byte[] bytes) {
+        String result = "";
+        for (byte b : bytes) {
+            result += Integer.toBinaryString((b & 0xFF) + 0x100).substring(1);
+            result += " ";
+        }
+        return result;
+    }
+
+    public static byte[] decimalToBCD(long num) {
+        int digits = 0;
+
+        long temp = num;
+        while (temp != 0) {
+            digits++;
+            temp /= 10;
+        }
+
+        boolean isOdd = digits % 2 == 0 ? false : true;
+        if (isOdd) {
+            digits++;
+        }
+        int byteLen = digits / 2;
+
+        byte bcd[] = new byte[byteLen];
+
+        for (int i = 0; i < digits; i++) {
+            byte tmp = (byte) (num % 10);
+            if(isOdd && i==0) {
+                bcd[i / 2] = tmp;
+                num /= 10;
+                i++;
+                continue;
+            }
+            if (i % 2 == 0) {
+                bcd[i / 2] = (byte) (tmp << 4);
+            } else {
+                bcd[i / 2] |= tmp;
+            }
+
+            num /= 10;
+        }
+
+        for (int i = 0; i < byteLen / 2; i++) {
+            byte tmp = bcd[i];
+            bcd[i] = bcd[byteLen - i - 1];
+            bcd[byteLen - i - 1] = tmp;
+        }
+
+        return bcd;
+    }
+
+    public static long bcdToDecimal(boolean isOdd, byte[] bcd) {
+        return Long.valueOf(bcdToString(isOdd, bcd));
+    }
+
+    public static String bcdToString(byte bcd) {
+        StringBuffer sb = new StringBuffer();
+
+        byte high = (byte) (bcd & 0xf0);
+        high >>>= (byte) 4;
+        high = (byte) (high & 0x0f);
+        byte low = (byte) (bcd & 0x0f);
+
+        sb.append(low);
+        sb.append(high);
+
+        return sb.toString();
+    }
+
+    public static String bcdToString(boolean isOdd, byte[] bcd) {
+        StringBuffer sb = new StringBuffer();
+
+        for (int i = 0; i < bcd.length; i++) {
+            sb.append(bcdToString(bcd[i]));
+        }
+
+        if(isOdd) {
+            sb.deleteCharAt(sb.length()-1);
+        }
+        return sb.toString();
+    }
+}

--- a/isup/isup-impl/src/test/java/org/mobicents/protocols/ss7/isup/impl/message/parameter/GenericDigitsTest.java
+++ b/isup/isup-impl/src/test/java/org/mobicents/protocols/ss7/isup/impl/message/parameter/GenericDigitsTest.java
@@ -25,6 +25,7 @@ package org.mobicents.protocols.ss7.isup.impl.message.parameter;
 import javolution.xml.XMLObjectReader;
 import javolution.xml.XMLObjectWriter;
 import org.mobicents.protocols.ss7.isup.message.parameter.GenericDigits;
+import org.mobicents.protocols.ss7.isup.util.BcdHelper;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
@@ -149,6 +150,21 @@ public class GenericDigitsTest {
         encodedData = prim.encode();
         assertTrue(Arrays.equals(data, encodedData));
     }
+
+    @Test(groups = { "functional.decode", "parameter" })
+    public void testSetDecodedHexDigits() throws Exception {
+        String hexString = "0123456789abcdef*#";
+        System.out.println("Test input digits: " + hexString);
+        GenericDigitsImpl prim = new GenericDigitsImpl();
+        prim.setDecodedDigits(GenericDigits._ENCODING_SCHEME_BCD_EVEN, hexString );
+        prim.setTypeOfDigits(GenericDigits._TOD_BGCI);
+        String decodedDigitsString = prim.getDecodedDigits();
+        System.out.println("Decoded  digits: " + decodedDigitsString);
+        String convertedDigits = BcdHelper.convertTelcoCharsToHexDigits(decodedDigitsString);
+        assertTrue(BcdHelper.convertTelcoCharsToHexDigits(hexString).equals(convertedDigits));
+    }
+
+
 
     @Test(groups = { "functional.xml.serialize", "parameter" })
     public void testXMLSerialize() throws Exception {

--- a/isup/isup-impl/src/test/java/org/mobicents/protocols/ss7/isup/impl/message/parameter/GenericDigitsTest.java
+++ b/isup/isup-impl/src/test/java/org/mobicents/protocols/ss7/isup/impl/message/parameter/GenericDigitsTest.java
@@ -22,22 +22,21 @@
 
 package org.mobicents.protocols.ss7.isup.impl.message.parameter;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.util.Arrays;
-
 import javolution.xml.XMLObjectReader;
 import javolution.xml.XMLObjectWriter;
-
 import org.mobicents.protocols.ss7.isup.message.parameter.GenericDigits;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  *
@@ -61,44 +60,101 @@ public class GenericDigitsTest {
     public void tearDown() {
     }
 
-    private byte[] getData() {
-        return new byte[] { 35, 0x21, 0x43, 0x65 }; // "123456" EVEN
+    private byte[] getEvenData() {
+        return new byte[] { 3, 0x21, 0x43, 0x65 }; // "123456" EVEN
     }
 
-    private byte[] getEncodedData() {
+    private byte[] getOddData() {
+        return new byte[] { 35, 0x21, 0x43, 0x65, 0x07 }; // "1234567" ODD
+    }
+
+    private byte[] getEncodedEvenData() {
         return new byte[] { 0x21, 0x43, 0x65 };
     }
 
+    private byte[] getEncodedOddData() {
+        return new byte[] { 0x21, 0x43, 0x65, 0x07 };
+    }
+
+    private String digitsEvenString = "123456";
+
+    private String digitsOddString = "1234567";
+
     @Test(groups = { "functional.decode", "parameter" })
-    public void testDecode() throws Exception {
+    public void testDecodeEven() throws Exception {
 
         GenericDigitsImpl prim = new GenericDigitsImpl();
-        prim.decode(getData());
+        prim.decode(getEvenData());
+
+        assertEquals(prim.getEncodingScheme(), GenericDigits._ENCODING_SCHEME_BCD_EVEN);
+        assertEquals(prim.getTypeOfDigits(), GenericDigits._TOD_BGCI);
+        assertEquals(prim.getEncodedDigits(), getEncodedEvenData());
+    }
+
+    @Test(groups = { "functional.decode", "parameter" })
+    public void testDecodeOdd() throws Exception {
+
+        GenericDigitsImpl prim = new GenericDigitsImpl();
+        prim.decode(getOddData());
 
         assertEquals(prim.getEncodingScheme(), GenericDigits._ENCODING_SCHEME_BCD_ODD);
         assertEquals(prim.getTypeOfDigits(), GenericDigits._TOD_BGCI);
-        assertEquals(prim.getEncodedDigits(), getEncodedData());
+        assertEquals(prim.getEncodedDigits(), getEncodedOddData());
     }
 
     @Test(groups = { "functional.encode", "parameter" })
-    public void testEncode() throws Exception {
+    public void testEncodeEven() throws Exception {
 
-        GenericDigitsImpl prim = new GenericDigitsImpl(GenericDigits._ENCODING_SCHEME_BCD_ODD, GenericDigits._TOD_BGCI,
-                getEncodedData());
+        GenericDigitsImpl prim = new GenericDigitsImpl(GenericDigits._ENCODING_SCHEME_BCD_EVEN, GenericDigits._TOD_BGCI,
+                                                       getEncodedEvenData());
         // int encodingScheme, int typeOfDigits, byte[] digits
 
-        byte[] data = getData();
+        byte[] data = getEvenData();
         byte[] encodedData = prim.encode();
 
         assertTrue(Arrays.equals(data, encodedData));
 
     }
 
+    @Test(groups = { "functional.encode", "parameter" })
+    public void testEncodeOdd() throws Exception {
+
+        GenericDigitsImpl prim = new GenericDigitsImpl(GenericDigits._ENCODING_SCHEME_BCD_ODD, GenericDigits._TOD_BGCI,
+                                                       getEncodedOddData());
+        // int encodingScheme, int typeOfDigits, byte[] digits
+
+        byte[] data = getOddData();
+        byte[] encodedData = prim.encode();
+
+        assertTrue(Arrays.equals(data, encodedData));
+
+    }
+
+    @Test(groups = { "functional.encode", "parameter" })
+    public void testSetDecodedDigits() throws Exception {
+
+        GenericDigitsImpl prim = new GenericDigitsImpl();
+        prim.setDecodedDigits(GenericDigits._ENCODING_SCHEME_BCD_EVEN, digitsEvenString );
+        prim.setTypeOfDigits(GenericDigits._TOD_BGCI);
+        assertTrue(digitsEvenString.equals(prim.getDecodedDigits()));
+
+        byte[] data = getEvenData();
+        byte[] encodedData = prim.encode();
+        assertTrue(Arrays.equals(data, encodedData));
+
+        prim.setDecodedDigits(GenericDigits._ENCODING_SCHEME_BCD_ODD, digitsOddString );
+        prim.setTypeOfDigits(GenericDigits._TOD_BGCI);
+        assertTrue(digitsOddString.equals(prim.getDecodedDigits()));
+        data = getOddData();
+        encodedData = prim.encode();
+        assertTrue(Arrays.equals(data, encodedData));
+    }
+
     @Test(groups = { "functional.xml.serialize", "parameter" })
     public void testXMLSerialize() throws Exception {
 
-        GenericDigitsImpl original = new GenericDigitsImpl(GenericDigits._ENCODING_SCHEME_BCD_ODD, GenericDigits._TOD_BGCI,
-                getEncodedData());
+        GenericDigitsImpl original = new GenericDigitsImpl(GenericDigits._ENCODING_SCHEME_BCD_EVEN, GenericDigits._TOD_BGCI,
+                                                           getEncodedEvenData());
 
         // Writes the area to a file.
         ByteArrayOutputStream baos = new ByteArrayOutputStream();


### PR DESCRIPTION
Hello,
I created BCD String support for GenericDigits based on the modified code of https://gist.github.com/neuro-sys/953548.

Also updated unit tests in order to test the change and cover ODD/EVEN digits encoding.