### PR TITLE
Add get/set idle timeout to CAP and MAP dialog intefaces

### DIFF
--- a/cap/cap-api/src/main/java/org/mobicents/protocols/ss7/cap/api/CAPDialog.java
+++ b/cap/cap-api/src/main/java/org/mobicents/protocols/ss7/cap/api/CAPDialog.java
@@ -286,4 +286,17 @@ public interface CAPDialog extends Serializable {
      * @return
      */
      int getMessageUserDataLengthOnClose(boolean prearrangedEnd) throws CAPException;
+
+     /**
+     *
+     * @return IdleTaskTimeout value in milliseconds
+     */
+     long getIdleTaskTimeout();
+
+     /**
+      * Set IdleTaskTimeout in milliseconds.
+      *
+      * @param idleTaskTimeoutMs
+      */
+     void setIdleTaskTimeout(long idleTaskTimeoutMs);
 }

--- a/cap/cap-impl/src/main/java/org/mobicents/protocols/ss7/cap/CAPDialogImpl.java
+++ b/cap/cap-impl/src/main/java/org/mobicents/protocols/ss7/cap/CAPDialogImpl.java
@@ -597,4 +597,11 @@ public abstract class CAPDialogImpl implements CAPDialog {
         No, Continue, End, PrearrangedEnd;
     }
 
+    public long getIdleTaskTimeout() {
+        return tcapDialog.getIdleTaskTimeout();
+    }
+
+    public void setIdleTaskTimeout(long idleTaskTimeoutMs) {
+        tcapDialog.setIdleTaskTimeout(idleTaskTimeoutMs);
+    }
 }

--- a/map/map-api/src/main/java/org/mobicents/protocols/ss7/map/api/MAPDialog.java
+++ b/map/map-api/src/main/java/org/mobicents/protocols/ss7/map/api/MAPDialog.java
@@ -354,4 +354,18 @@ public interface MAPDialog extends Serializable {
      * @param vlrNo
      */
     void addEricssonData(IMSI imsi, AddressString vlrNo);
+
+    /**
+    * Return the value of the IdleTaskTimeout of the TCAP Dialog in milliseconds.
+    *
+    * @return TCAP IdleTaskTimeout value in milliseconds
+    */
+    long getIdleTaskTimeout();
+
+    /**
+     * Set TCAP IdleTaskTimeout in milliseconds.
+     *
+     * @param idleTaskTimeoutMs
+     */
+    void setIdleTaskTimeout(long idleTaskTimeoutMs);
 }

--- a/map/map-impl/src/main/java/org/mobicents/protocols/ss7/map/MAPDialogImpl.java
+++ b/map/map-impl/src/main/java/org/mobicents/protocols/ss7/map/MAPDialogImpl.java
@@ -654,4 +654,12 @@ public abstract class MAPDialogImpl implements MAPDialog {
     protected enum DelayedAreaState {
         No, Continue, End, PrearrangedEnd;
     }
+
+    public long getIdleTaskTimeout() {
+        return tcapDialog.getIdleTaskTimeout();
+    }
+
+    public void setIdleTaskTimeout(long idleTaskTimeoutMs) {
+        tcapDialog.setIdleTaskTimeout(idleTaskTimeoutMs);
+    }
 }

--- a/tcap/tcap-api/src/main/java/org/mobicents/protocols/ss7/tcap/api/tc/dialog/Dialog.java
+++ b/tcap/tcap-api/src/main/java/org/mobicents/protocols/ss7/tcap/api/tc/dialog/Dialog.java
@@ -304,4 +304,15 @@ public interface Dialog extends Serializable {
      */
     ReentrantLock getDialogLock();
 
+    /**
+    *
+    * @return IdleTaskTimeout value in milliseconds
+    */
+   long getIdleTaskTimeout();
+
+    /**
+     * Set IdleTaskTimeout in milliseconds.
+     */
+    void setIdleTaskTimeout(long idleTaskTimeoutMs);
+
 }

--- a/tcap/tcap-impl/src/main/java/org/mobicents/protocols/ss7/tcap/DialogImpl.java
+++ b/tcap/tcap-impl/src/main/java/org/mobicents/protocols/ss7/tcap/DialogImpl.java
@@ -2168,6 +2168,14 @@ public class DialogImpl implements Dialog {
         return this.prevewDialogData;
     }
 
+    public long getIdleTaskTimeout() {
+        return this.idleTaskTimeout;
+    }
+
+    public void setIdleTaskTimeout(long idleTaskTimeoutMs) {
+        this.idleTaskTimeout = idleTaskTimeoutMs;
+    }
+
     /*
      * (non-Javadoc)
      *


### PR DESCRIPTION
Hello @vetss,

This PR is the implementation of topic #119:
Add getter/setter methods for accessing idle task timeout value of the TCAP dialog to TCAP, CAP and MAP dialogs.

I don't know if this feature is useful or not in TCAP ANSI dialog too, because I don't know how TCAP ANSI stack should be used. Can you for example use a CAP stack above TCAP ANSI stack and how?

Thanks!

Regards,
Gabor