### PR TITLE
Implement suppress-N-CSI in CAP ConnectRequest

### DIFF
--- a/cap/cap-api/src/main/java/org/mobicents/protocols/ss7/cap/api/service/circuitSwitchedCall/CAPDialogCircuitSwitchedCall.java
+++ b/cap/cap-api/src/main/java/org/mobicents/protocols/ss7/cap/api/service/circuitSwitchedCall/CAPDialogCircuitSwitchedCall.java
@@ -147,7 +147,7 @@ public interface CAPDialogCircuitSwitchedCall extends CAPDialog {
             RedirectionInformationInap redirectionInformation, ArrayList<GenericNumberCap> genericNumbers,
             ServiceInteractionIndicatorsTwo serviceInteractionIndicatorsTwo, LocationNumberCap chargeNumber,
             LegID legToBeConnected, CUGInterlock cugInterlock, boolean cugOutgoingAccess, boolean suppressionOfAnnouncement,
-            boolean ocsIApplicable, NAOliInfo naoliInfo, boolean borInterrogationRequested) throws CAPException;
+            boolean ocsIApplicable, NAOliInfo naoliInfo, boolean borInterrogationRequested, boolean suppressNCSI) throws CAPException;
 
     Long addConnectRequest(int customInvokeTimeout, DestinationRoutingAddress destinationRoutingAddress,
             AlertingPatternCap alertingPattern, OriginalCalledNumberCap originalCalledPartyID, CAPExtensions extensions,
@@ -155,7 +155,7 @@ public interface CAPDialogCircuitSwitchedCall extends CAPDialog {
             RedirectionInformationInap redirectionInformation, ArrayList<GenericNumberCap> genericNumbers,
             ServiceInteractionIndicatorsTwo serviceInteractionIndicatorsTwo, LocationNumberCap chargeNumber,
             LegID legToBeConnected, CUGInterlock cugInterlock, boolean cugOutgoingAccess, boolean suppressionOfAnnouncement,
-            boolean ocsIApplicable, NAOliInfo naoliInfo, boolean borInterrogationRequested) throws CAPException;
+            boolean ocsIApplicable, NAOliInfo naoliInfo, boolean borInterrogationRequested, boolean suppressNCSI) throws CAPException;
 
     Long addContinueRequest() throws CAPException;
 

--- a/cap/cap-api/src/main/java/org/mobicents/protocols/ss7/cap/api/service/circuitSwitchedCall/ConnectRequest.java
+++ b/cap/cap-api/src/main/java/org/mobicents/protocols/ss7/cap/api/service/circuitSwitchedCall/ConnectRequest.java
@@ -72,6 +72,7 @@ ConnectArg {PARAMETERS-BOUND : bound} ::= SEQUENCE {
   naOliInfo                     [57] NAOliInfo OPTIONAL,
   bor-InterrogationRequested    [58] NULL OPTIONAL,
   ...
+  suppress-N-CSI                [59] NULL OPTIONAL
 }
 -- na-Info is included at the discretion of the gsmSCF operator.
 
@@ -85,7 +86,7 @@ OCSIApplicable ::= NULL
  *
  *
  * @author sergey vetyutnev
- *
+ * @author tamas gyorgyey
  */
 public interface ConnectRequest extends CircuitSwitchedCallMessage {
 
@@ -124,5 +125,7 @@ public interface ConnectRequest extends CircuitSwitchedCallMessage {
     NAOliInfo getNAOliInfo();
 
     boolean getBorInterrogationRequested();
+
+    boolean getSuppressNCSI();
 
 }

--- a/cap/cap-impl/src/main/java/org/mobicents/protocols/ss7/cap/service/circuitSwitchedCall/CAPDialogCircuitSwitchedCallImpl.java
+++ b/cap/cap-impl/src/main/java/org/mobicents/protocols/ss7/cap/service/circuitSwitchedCall/CAPDialogCircuitSwitchedCallImpl.java
@@ -96,7 +96,7 @@ import org.mobicents.protocols.ss7.tcap.asn.comp.ReturnResultLast;
 /**
  *
  * @author sergey vetyutnev
- *
+ * @author alerant appngin
  */
 public class CAPDialogCircuitSwitchedCallImpl extends CAPDialogImpl implements CAPDialogCircuitSwitchedCall {
 
@@ -414,12 +414,12 @@ public class CAPDialogCircuitSwitchedCallImpl extends CAPDialogImpl implements C
             RedirectionInformationInap redirectionInformation, ArrayList<GenericNumberCap> genericNumbers,
             ServiceInteractionIndicatorsTwo serviceInteractionIndicatorsTwo, LocationNumberCap chargeNumber,
             LegID legToBeConnected, CUGInterlock cugInterlock, boolean cugOutgoingAccess, boolean suppressionOfAnnouncement,
-            boolean ocsIApplicable, NAOliInfo naoliInfo, boolean borInterrogationRequested) throws CAPException {
+            boolean ocsIApplicable, NAOliInfo naoliInfo, boolean borInterrogationRequested, boolean suppressNCSI) throws CAPException {
 
         return addConnectRequest(_Timer_Default, destinationRoutingAddress, alertingPattern, originalCalledPartyID, extensions,
                 carrier, callingPartysCategory, redirectingPartyID, redirectionInformation, genericNumbers,
                 serviceInteractionIndicatorsTwo, chargeNumber, legToBeConnected, cugInterlock, cugOutgoingAccess,
-                suppressionOfAnnouncement, ocsIApplicable, naoliInfo, borInterrogationRequested);
+                suppressionOfAnnouncement, ocsIApplicable, naoliInfo, borInterrogationRequested, suppressNCSI);
     }
 
     @Override
@@ -429,7 +429,7 @@ public class CAPDialogCircuitSwitchedCallImpl extends CAPDialogImpl implements C
             RedirectionInformationInap redirectionInformation, ArrayList<GenericNumberCap> genericNumbers,
             ServiceInteractionIndicatorsTwo serviceInteractionIndicatorsTwo, LocationNumberCap chargeNumber,
             LegID legToBeConnected, CUGInterlock cugInterlock, boolean cugOutgoingAccess, boolean suppressionOfAnnouncement,
-            boolean ocsIApplicable, NAOliInfo naoliInfo, boolean borInterrogationRequested) throws CAPException {
+            boolean ocsIApplicable, NAOliInfo naoliInfo, boolean borInterrogationRequested, boolean suppressNCSI) throws CAPException {
 
         if (this.appCntx != CAPApplicationContext.CapV1_gsmSSF_to_gsmSCF
                 && this.appCntx != CAPApplicationContext.CapV2_gsmSSF_to_gsmSCF
@@ -453,7 +453,7 @@ public class CAPDialogCircuitSwitchedCallImpl extends CAPDialogImpl implements C
         ConnectRequestImpl req = new ConnectRequestImpl(destinationRoutingAddress, alertingPattern, originalCalledPartyID,
                 extensions, carrier, callingPartysCategory, redirectingPartyID, redirectionInformation, genericNumbers,
                 serviceInteractionIndicatorsTwo, chargeNumber, legToBeConnected, cugInterlock, cugOutgoingAccess,
-                suppressionOfAnnouncement, ocsIApplicable, naoliInfo, borInterrogationRequested);
+                suppressionOfAnnouncement, ocsIApplicable, naoliInfo, borInterrogationRequested, suppressNCSI);
         AsnOutputStream aos = new AsnOutputStream();
         req.encodeData(aos);
 

--- a/cap/cap-impl/src/main/java/org/mobicents/protocols/ss7/cap/service/circuitSwitchedCall/ConnectRequestImpl.java
+++ b/cap/cap-impl/src/main/java/org/mobicents/protocols/ss7/cap/service/circuitSwitchedCall/ConnectRequestImpl.java
@@ -1,4 +1,4 @@
-/*
+    /*
  * TeleStax, Open Source Cloud Communications  Copyright 2012.
  * and individual contributors
  * by the @authors tag. See the copyright.txt in the distribution for a
@@ -75,7 +75,7 @@ import org.mobicents.protocols.ss7.map.service.mobility.subscriberManagement.CUG
 /**
  *
  * @author sergey vetyutnev
- *
+ * @author tamas gyorgyey
  */
 public class ConnectRequestImpl extends CircuitSwitchedCallMessageImpl implements ConnectRequest {
 
@@ -97,6 +97,7 @@ public class ConnectRequestImpl extends CircuitSwitchedCallMessageImpl implement
     public static final int _ID_oCSIApplicable = 56;
     public static final int _ID_naOliInfo = 57;
     public static final int _ID_bor_InterrogationRequested = 58;
+    public static final int _ID_suppressNCSI = 59;
 
     private static final String DESTINATION_ROUTING_ADDRESS = "destinationRoutingAddress";
     private static final String ALERTING_PATTERN = "alertingPattern";
@@ -117,6 +118,7 @@ public class ConnectRequestImpl extends CircuitSwitchedCallMessageImpl implement
     private static final String OCSI_APPLICABLE = "OCSIApplicable";
     private static final String NA_OLI_INFO = "NAOliInfo";
     private static final String BOR_INTERROGATION_REQUESTED = "borInterrogationRequested";
+    private static final String SUPPRESS_N_CSI = "suppressNCSI";
 
     public static final String _PrimitiveName = "ConnectRequestIndication";
 
@@ -138,6 +140,7 @@ public class ConnectRequestImpl extends CircuitSwitchedCallMessageImpl implement
     private boolean ocsIApplicable;
     private NAOliInfo naoliInfo;
     private boolean borInterrogationRequested;
+    private boolean suppressNCSI;
 
     public ConnectRequestImpl() {
     }
@@ -148,7 +151,7 @@ public class ConnectRequestImpl extends CircuitSwitchedCallMessageImpl implement
             RedirectionInformationInap redirectionInformation, ArrayList<GenericNumberCap> genericNumbers,
             ServiceInteractionIndicatorsTwo serviceInteractionIndicatorsTwo, LocationNumberCap chargeNumber,
             LegID legToBeConnected, CUGInterlock cugInterlock, boolean cugOutgoingAccess, boolean suppressionOfAnnouncement,
-            boolean ocsIApplicable, NAOliInfo naoliInfo, boolean borInterrogationRequested) {
+            boolean ocsIApplicable, NAOliInfo naoliInfo, boolean borInterrogationRequested, boolean suppressNCSI) {
         this.destinationRoutingAddress = destinationRoutingAddress;
         this.alertingPattern = alertingPattern;
         this.originalCalledPartyID = originalCalledPartyID;
@@ -167,6 +170,7 @@ public class ConnectRequestImpl extends CircuitSwitchedCallMessageImpl implement
         this.ocsIApplicable = ocsIApplicable;
         this.naoliInfo = naoliInfo;
         this.borInterrogationRequested = borInterrogationRequested;
+        this.suppressNCSI = suppressNCSI;
     }
 
     @Override
@@ -270,6 +274,11 @@ public class ConnectRequestImpl extends CircuitSwitchedCallMessageImpl implement
     }
 
     @Override
+    public boolean getSuppressNCSI() {
+        return suppressNCSI;
+    }
+
+    @Override
     public int getTag() throws CAPException {
         return Tag.SEQUENCE;
     }
@@ -346,6 +355,7 @@ public class ConnectRequestImpl extends CircuitSwitchedCallMessageImpl implement
         this.ocsIApplicable = false;
         this.naoliInfo = null;
         this.borInterrogationRequested = false;
+        this.suppressNCSI = false;
 
         AsnInputStream ais = ansIS.readSequenceStreamData(length);
         while (true) {
@@ -443,6 +453,10 @@ public class ConnectRequestImpl extends CircuitSwitchedCallMessageImpl implement
                 case _ID_bor_InterrogationRequested:
                     ais.readNull();
                     this.borInterrogationRequested = true;
+                    break;
+                case _ID_suppressNCSI:
+                    ais.readNull();
+                    this.suppressNCSI = true;
                     break;
 
                 default:
@@ -548,6 +562,9 @@ public class ConnectRequestImpl extends CircuitSwitchedCallMessageImpl implement
             if (this.borInterrogationRequested) {
                 aos.writeNull(Tag.CLASS_CONTEXT_SPECIFIC, _ID_bor_InterrogationRequested);
             }
+            if (this.suppressNCSI) {
+                aos.writeNull(Tag.CLASS_CONTEXT_SPECIFIC, _ID_suppressNCSI);
+            }
 
         } catch (IOException e) {
             throw new CAPException("IOException when encoding " + _PrimitiveName + ": " + e.getMessage(), e);
@@ -644,6 +661,9 @@ public class ConnectRequestImpl extends CircuitSwitchedCallMessageImpl implement
         if (this.borInterrogationRequested) {
             sb.append(", borInterrogationRequested");
         }
+        if (this.suppressNCSI) {
+            sb.append(", suppressNCSI");
+        }
 
         sb.append("]");
 
@@ -697,6 +717,10 @@ public class ConnectRequestImpl extends CircuitSwitchedCallMessageImpl implement
             bval = xml.get(BOR_INTERROGATION_REQUESTED, Boolean.class);
             if (bval != null)
                 connectRequest.borInterrogationRequested = bval;
+            bval = xml.get(SUPPRESS_N_CSI, Boolean.class);
+            if (bval != null)
+                connectRequest.suppressNCSI = bval;
+
         }
 
         @Override
@@ -755,6 +779,8 @@ public class ConnectRequestImpl extends CircuitSwitchedCallMessageImpl implement
 
             if (connectRequest.borInterrogationRequested)
                 xml.add(true, BOR_INTERROGATION_REQUESTED, Boolean.class);
+            if (connectRequest.suppressNCSI)
+                xml.add(true, SUPPRESS_N_CSI, Boolean.class);
         }
     };
 

--- a/cap/cap-impl/src/test/java/org/mobicents/protocols/ss7/cap/CallScfExample.java
+++ b/cap/cap-impl/src/test/java/org/mobicents/protocols/ss7/cap/CallScfExample.java
@@ -175,7 +175,7 @@ public class CallScfExample implements CAPDialogListener, CAPServiceCircuitSwitc
                             DestinationRoutingAddress destinationRoutingAddress = this.capProvider.getCAPParameterFactory()
                                     .createDestinationRoutingAddress(calledPartyNumber);
                             currentCapDialog.addConnectRequest(destinationRoutingAddress, null, null, null, null, null, null,
-                                    null, null, null, null, null, null, false, false, false, null, false);
+                                    null, null, null, null, null, null, false, false, false, null, false, false);
                         } else {
                             // sending Continue to use the original calledPartyAddress
                             currentCapDialog.addContinueRequest();

--- a/cap/cap-impl/src/test/java/org/mobicents/protocols/ss7/cap/functional/CAPFunctionalTest.java
+++ b/cap/cap-impl/src/test/java/org/mobicents/protocols/ss7/cap/functional/CAPFunctionalTest.java
@@ -694,7 +694,7 @@ TC-CONTINUE + EventReportBCSMRequest (ODisconnect)
                             DestinationRoutingAddress destinationRoutingAddress = this.capParameterFactory
                                     .createDestinationRoutingAddress(calledPartyNumber);
                             dlg.addConnectRequest(destinationRoutingAddress, null, null, null, null, null, null, null, null,
-                                    null, null, null, null, false, false, false, null, false);
+                                    null, null, null, null, false, false, false, null, false, false);
                             this.observerdEvents.add(TestEvent.createSentEvent(EventType.ConnectRequest, null, sequence++));
                             dlg.send();
 

--- a/cap/cap-impl/src/test/java/org/mobicents/protocols/ss7/cap/service/circuitSwitchedCall/ConnectRequestTest.java
+++ b/cap/cap-impl/src/test/java/org/mobicents/protocols/ss7/cap/service/circuitSwitchedCall/ConnectRequestTest.java
@@ -90,9 +90,9 @@ public class ConnectRequestTest {
     }
 
     public byte[] getData4() {
-        return new byte[] { 48, 49, (byte) 160, 7, 4, 5, 2, 16, 121, 34, 16, (byte) 139, 4, 11, 12, 13, 14, (byte) 175, 5, (byte) 160, 3, (byte) 129, 1, 2,
+        return new byte[] { 48, 52, (byte) 160, 7, 4, 5, 2, 16, 121, 34, 16, (byte) 139, 4, 11, 12, 13, 14, (byte) 175, 5, (byte) 160, 3, (byte) 129, 1, 2,
                 (byte) 147, 7, 4, 0, 0, 0, 112, 119, 119, (byte) 181, 3, (byte) 128, 1, 5, (byte) 159, 31, 4, 21, 22, 23, 24, (byte) 159, 32, 0, (byte) 159,
-                58, 0 };
+                58, 0, (byte) 159, 59, 0 };
     }
 
     public byte[] getDataGenericNumber() {
@@ -147,6 +147,7 @@ public class ConnectRequestTest {
         assertNull(elem.getCUGInterlock());
         assertFalse(elem.getCugOutgoingAccess());
         assertFalse(elem.getBorInterrogationRequested());
+        assertFalse(elem.getSuppressNCSI());
 
 
         data = this.getData2();
@@ -172,6 +173,7 @@ public class ConnectRequestTest {
         assertNull(elem.getCUGInterlock());
         assertFalse(elem.getCugOutgoingAccess());
         assertFalse(elem.getBorInterrogationRequested());
+        assertFalse(elem.getSuppressNCSI());
 
 
         data = this.getData3();
@@ -206,7 +208,7 @@ public class ConnectRequestTest {
         assertNull(elem.getCUGInterlock());
         assertFalse(elem.getCugOutgoingAccess());
         assertFalse(elem.getBorInterrogationRequested());
-
+        assertFalse(elem.getSuppressNCSI());
 
         data = this.getData4();
         ais = new AsnInputStream(data);
@@ -241,6 +243,7 @@ public class ConnectRequestTest {
         assertEquals(elem.getCUGInterlock().getData(), getCUGInterlockData());
         assertTrue(elem.getCugOutgoingAccess());
         assertTrue(elem.getBorInterrogationRequested());
+        assertTrue(elem.getSuppressNCSI());
     }
 
     @Test(groups = { "functional.encode", "circuitSwitchedCall" })
@@ -253,7 +256,7 @@ public class ConnectRequestTest {
         DestinationRoutingAddressImpl destinationRoutingAddress = new DestinationRoutingAddressImpl(calledPartyNumbers);
 
         ConnectRequestImpl elem = new ConnectRequestImpl(destinationRoutingAddress, null, null, null, null, null, null, null,
-                null, null, null, null, null, false, false, false, null, false);
+                null, null, null, null, null, false, false, false, null, false, false);
         AsnOutputStream aos = new AsnOutputStream();
         elem.encodeAll(aos);
         assertTrue(Arrays.equals(aos.toByteArray(), this.getData1()));
@@ -262,7 +265,7 @@ public class ConnectRequestTest {
         GenericNumberCapImpl genericNumberCap = new GenericNumberCapImpl(getDataGenericNumber());
         genericNumbers.add(genericNumberCap);
         elem = new ConnectRequestImpl(destinationRoutingAddress, null, null, null, null, null, null, null, genericNumbers,
-                null, null, null, null, false, false, false, null, false);
+                null, null, null, null, false, false, false, null, false, false);
         aos = new AsnOutputStream();
         elem.encodeAll(aos);
         assertTrue(Arrays.equals(aos.toByteArray(), this.getData2()));
@@ -278,7 +281,7 @@ public class ConnectRequestTest {
 
         elem = new ConnectRequestImpl(destinationRoutingAddress, alertingPatternCap, originalCalledPartyID,
                 CAPExtensionsTest.createTestCAPExtensions(), null, callingPartysCategory, redirectingPartyID,
-                redirectionInformation, genericNumbers, null, null, null, null, false, true, true, naoliInfo, false);
+                redirectionInformation, genericNumbers, null, null, null, null, false, true, true, naoliInfo, false, false);
         aos = new AsnOutputStream();
         elem.encodeAll(aos);
         assertTrue(Arrays.equals(aos.toByteArray(), this.getData3()));
@@ -295,7 +298,7 @@ public class ConnectRequestTest {
         LegID legToBeConnected = new LegIDImpl(true, LegType.leg5);
         CUGInterlock cugInterlock = new CUGInterlockImpl(getCUGInterlockData());
         elem = new ConnectRequestImpl(destinationRoutingAddress, null, null, null, carrier, null, null, null, null, serviceInteractionIndicatorsTwo,
-                chargeNumber, legToBeConnected, cugInterlock, true, false, false, null, true);
+                chargeNumber, legToBeConnected, cugInterlock, true, false, false, null, true, true);
         aos = new AsnOutputStream();
         elem.encodeAll(aos);
         assertTrue(Arrays.equals(aos.toByteArray(), this.getData4()));
@@ -335,7 +338,7 @@ public class ConnectRequestTest {
         ConnectRequestImpl original = new ConnectRequestImpl(destinationRoutingAddress, alertingPatternCap,
                 originalCalledPartyID, CAPExtensionsTest.createTestCAPExtensions(), null, callingPartysCategory,
                 redirectingPartyID, redirectionInformation, genericNumbers, null, null, null, null, false, true, true,
-                naoliInfo, false);
+                naoliInfo, false, false);
         original.setInvokeId(24);
 
         // Writes the area to a file.
@@ -389,7 +392,7 @@ public class ConnectRequestTest {
         LegID legToBeConnected = new LegIDImpl(true, LegType.leg5);
         CUGInterlock cugInterlock = new CUGInterlockImpl(getCUGInterlockData());
         original = new ConnectRequestImpl(destinationRoutingAddress, null, null, null, carrier, null, null, null, null, serviceInteractionIndicatorsTwo,
-                chargeNumber, legToBeConnected, cugInterlock, true, false, false, null, true);
+                chargeNumber, legToBeConnected, cugInterlock, true, false, false, null, true, true);
         original.setInvokeId(24);
 
         // Writes the area to a file.
@@ -436,5 +439,6 @@ public class ConnectRequestTest {
         assertEquals(copy.getCUGInterlock().getData(), original.getCUGInterlock().getData());
         assertEquals(copy.getCugOutgoingAccess(), original.getCugOutgoingAccess());
         assertEquals(copy.getBorInterrogationRequested(), original.getBorInterrogationRequested());
+        assertEquals(copy.getSuppressNCSI(), original.getSuppressNCSI());
     }
 }


### PR DESCRIPTION
Hello @vetss ,

This PR contains the implementation of the missing suppress-N-CSI handling in CAP ConnectRequest (issue #123).

Best Regards,
Gabor