### PR TITLE
Remove newline delimiter in UserServiceInformation output

### DIFF
--- a/isup/isup-impl/src/main/java/org/mobicents/protocols/ss7/isup/impl/message/parameter/UserServiceInformationBaseImpl.java
+++ b/isup/isup-impl/src/main/java/org/mobicents/protocols/ss7/isup/impl/message/parameter/UserServiceInformationBaseImpl.java
@@ -727,7 +727,7 @@ public abstract class UserServiceInformationBaseImpl extends AbstractISUPParamet
         sb.append(customInformationTransferRate);
 
         if (l1UserInformation > 0) {
-            sb.append(",\nl1UserInformation=");
+            sb.append(", l1UserInformation=");
             sb.append(l1UserInformation);
 
             sb.append(", syncMode=");
@@ -767,12 +767,12 @@ public abstract class UserServiceInformationBaseImpl extends AbstractISUPParamet
         }
 
         if (l2UserInformation > 0) {
-            sb.append("\nl2UserInformation=");
+            sb.append(", l2UserInformation=");
             sb.append(l2UserInformation);
         }
 
         if (l3UserInformation > 0) {
-            sb.append("\nl3UserInformation=");
+            sb.append(", l3UserInformation=");
             sb.append(l3UserInformation);
 
             sb.append(", l3Protocol=");


### PR DESCRIPTION
I'm not sure if we should ever add new line separator into 'toString' output.

You cannot simple check those logs with 'grep' if your operation has been separated on multiple lines:
```
[2016-07-27 10:33:37] 4742 [Mtp3-DeliveryExecutor-1-2-1] INFO  c.f.f.c.FusionCAPServiceListener - #onCAPMessage, capMessage = InitialDPRequestIndication [InvokeId=0, serviceKey=1, callingPartyNumber=CallingPartyNumberCap [data=[XXX ], CallingPartyNumber [numberingPlanIndicator=1, numberIncompleteIndicator=0, addressRepresentationREstrictedIndicator=0, screeningIndicator=3, natureOfAddresIndicator=3, oddFlag=0, address=XXXX11]], callingPartysCategory=CallingPartysCategoryInap [data=[10, ], CallingPartyCategory [callingPartyCategory=10]], locationNumber=LocationNumberCap [data=[XXX, ], LocationNumber [numberingPlanIndicator=1, internalNetworkNumberIndicator=0, addressRepresentationRestrictedIndicator=0, screeningIndicator=3, natureOfAddresIndicator=4, oddFlag=1, address=7]], bearerCapability=BearerCap [bearerCap=BearerCap [data=[XXX, ], UserServiceInformation [codingStandart=0, informationTransferCapability=0, transferMode=0, informationTransferRate=16, customInformationTransferRate=0,
l1UserInformation=3, syncMode=0, negotiation=0, userRate=0, intermediateRate=0, nicOnTx=0, fcOnTx=0, hdr=0, multiframe=0, mode=0, lli=0, assignor=0, inBandNegotiation=0, stopBits=0, dataBits=0, parity=0, duplexMode=0, modemType=0]]], eventTypeBCSM=collectedInfo, imsi=IMSI [XXX], locationInformation=LocationInformation [, ageOfLocationInformation=0, vlrNumber=ISDNAddressString[AddressNature=international_number, NumberingPlan=ISDN, Address=XXX01], cellGlobalIdOrServiceAreaIdOrLAI=[CellGlobalIdOrServiceAreaIdOrLAI [CellGlobalIdOrServiceAreaIdFixedLength [MCC=XXX, MNC=XX, Lac=XXXXX, CellId(SAC)=XXXXX]]]], extBasicServiceCode=ExtBasicServiceCode [ExtTeleserviceCode [Value=telephony, Data=[17, ]]], callReferenceNumber=CallReferenceNumber [Data= XXX], mscAddress=ISDNAddressString[AddressNature=international_number, NumberingPlan=ISDN, Address=XXX01], calledPartyBCDNumber=CalledPartyBCDNumber [addressNature=international_number, numberingPlan=ISDN, address=XXX91], timeAndTimezone=TimeAndTimezone [year=2016, month=7, day=13, hour=14, minite=10, second=6, timeZone=12]] 
```