### PR TITLE
add SS7 cards demo

### DIFF
--- a/docs/userguide/sources-asciidoc/src/main/asciidoc/Chapter-Running.adoc
+++ b/docs/userguide/sources-asciidoc/src/main/asciidoc/Chapter-Running.adoc
@@ -582,3 +582,86 @@ image::images/Simulator-Example5.png[]
 image::images/Simulator-Example6.png[]	
 
 . The Results of the tests can be found at the console (in the server) or in the log file (file name is "a1.log" where "a1" is the name of the Simulator instance).     
+
+[[_running_ss7_cards]]
+== Running with SS7 cards
+
+Apart from the simulator a {this-platform} USSD Demo SLEE Application has been tested with Dialogic's MAP Test Utility (MTU) tool in a process that is described below.
+ +
+It is assumed that you have two Servers (each fitted with Dialogic card) connected to each other via cross cable and the OS is Linux-based. To understand how to set-up the environment for Dialogic card please download respective Programmers Manual. This test was carried out on https://www.dialogic.com/~/media/manuals/ss7/cd/ProductSpecific/SPCI-CPM8/ProgrammersManual/SPCI-PM.pdf[Dialogic SPCI2S cards]. It is recommened to read the http://resource.dialogic.com/telecom/support/ss7/cd/GenericInfo/GeneralDocumentation/U30SSS03-MTU-MTR-UG.pdf[MTU/MTR guide] before proceeding further. 
+
+=== MTU setup
+
+Please download the http://www.dialogic.com/support/helpweb/helpweb.aspx/1580/ussd_map_sample_code/Signaling_SS7[modified MTU code for USSD] and build it to create the executable. 
+ 
+:configtxt: http://www.dialogic.com/den/cfs-file.ashx/__key/CommunityServer.Discussions.Components.Files/10/0654.config.txt
+:systemtxt: http://www.dialogic.com/den/cfs-file.ashx/__key/CommunityServer.Discussions.Components.Files/10/0121.system.txt
+
+Rename {configtxt}[this file] to config.txt and {systemtxt}[this file] to system.txt and place them at /opt/dpklnx/ before loading the driver and activating links. Its is assumed that MTP2/MTP3 is loaded onboard and Dialogic SCCP, TCAP, MAP and MTU is loaded on host system.
+ +
+Command at /opt/dpklnx/ to load drivers
+[source,bash]
+----
+/opt/dpklnx# ./gctload -d
+----
+
+Command at /opt/dpklnx/ to activate link
+[source,bash]
+----
+/opt/dpklnx# ./mtpsl act 0 0
+----
+
+Once the link is activated, don't forget to execute the mtucfg.ms7 script. This script registers the MTU with Dialogic SCCP stack.
+[source,bash]
+----
+./s7_play -f/home/abhayani/workarea/mobicents/dialogic/upd_tar_FILES/RUN/MTU/SCRIPTS/mtucfg.ms7
+----
+
+=== USSD Application Setup
+
+Download the configuration and system files for {this-platform} USSD from https://developer.jboss.org/wiki/USSDMAPTestingWithDialogicBoards[here] and rename them to config.txt and system.txt respectively and place it to corect folder (/opt/dpklnx/ for linux) before loading the driver and activating links. Use same commands as shown above to load drivers and activate link. It is assumed here that MTP2/MTP3 is loaded onboard. The Mobicents Dialogic native driver (libmobicents-dialogic-linux.so) communicates with MTP3 onboard.
+ +
+Once link is active start the {this-platform} JAIN SLEE (JBoss Application) Server. Remember before starting application server, place the native file in correct folder (for example incase of 32bit linux mobicents-jainslee-2.4.0.CR1-jboss-5.1.0.GA/jboss-5.1.0.GA/bin/META-INF/lib/linux2/x86/libmobicents-dialogic-linux.so) or the java.library.path should be set to point the directory containing native component.
+ +
+Deploy the {this-platform} SS7 Service as explained in Mobicents SS7 Docs.
+Deploy the {this-platform} MAP RA as explained in Mobicents JSLEE Docs. Use the following as map-default-ra.properties.
+[source,bash]
+----
+sccp.service=java:/mobicents/ss7/sccp
+sccp.pointcode=0
+sccp.ssn=8
+----
+Deploy your demo
+ +
+One last step before the application can be tested is configuring the Linkset and SCCP rule. Fire the CLI and connect to {this-platform} SS7 Service as explained in {this-platform} SS7 Doc. Following configuration is to be done only once and it survives system restarts.
+ +
+Execute bellow command to register routing rule based on DPC + SSN
+[source,bash]
+----
+mobicents(127.0.0.1:3435)>sccprule create Rule4 dpc 1 ssn 8 mtpinfo name name1 opc 2 apc 1 sls 16
+----
+
+Execute bellow command to register dialogic linkset
+[source,bash]
+----
+mobicents(127.0.0.1:3435)>linkset create dialogic opc 2 apc 1 ni 3 srcmod 61 destmod 34 linkset1
+----
+
+Execute bellow command to activate linkset
+[source,bash]
+----
+mobicents(10.65.208.215)>linkset activate linkset1
+----
+
+=== Test
+
+Execute the following MTU command from MTU machine
+[source,bash]
+----
+ussdtest -d6 -g43010008 -a43020008 -i987654321 -s"1" -U*88#
+----
+
+You should see the [INFO] messages in the Mobicents JAIN SLEE Server console about received USSD short codes and response sent.
+ 
+The /opt/dpklnx in both machines will have mtp.pcap and mtp.txt showing the USSD messages exchanged.
+


### PR DESCRIPTION
based on https://developer.jboss.org/wiki/USSDMAPTestingWithDialogicBoards

The link 'map-demo' is broken but the instructions show at least an actual usage of SS7 cards.

More specifically, the following link says 'SVN hosting has been permanently disabled'
https://code.google.com/p/mobicents/source/browse/#svn%2Ftrunk%2Fservers%2Fjain-slee%2Fexamples%2Fmap-demo