### PR TITLE
Sls patch non netty

### DIFF
--- a/docs/installationguide/sources-asciidoc/pom.xml
+++ b/docs/installationguide/sources-asciidoc/pom.xml
@@ -80,7 +80,6 @@
 								<jee-platform>${docs.jee.platform}</jee-platform>
 								<this-issue-tracker-url>${docs.this.issue.tracker.url}</this-issue-tracker-url>
 								<this-release-source-code-url>${docs.this.release.source.code.url}</this-release-source-code-url>
-								<this-trunk-source-code-url>${docs.this.trunk.source.code.url}</this-trunk-source-code-url>
 								<this-release-binary-url>${docs.this.release.binary.url}</this-release-binary-url>
 								<slee2-binary-url>${docs.slee2.binary.url}</slee2-binary-url>
 								<slee7-binary-url>${docs.slee7.binary.url}</slee7-binary-url>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -20,7 +20,6 @@
 		<docs.project.version>${project.version}</docs.project.version>
 		<docs.this.issue.tracker.url>https://github.com/Restcomm/jss7/issues</docs.this.issue.tracker.url>
 		<docs.this.release.source.code.url>https://github.com/Restcomm/jss7</docs.this.release.source.code.url>
-		<docs.this.trunk.source.code.url>https://github.com/Restcomm/jss7</docs.this.trunk.source.code.url>
 		<docs.this.release.binary.url>https://github.com/RestComm/jss7/releases/latest</docs.this.release.binary.url>
 		<docs.slee2.binary.url>https://github.com/RestComm/jain-slee/releases/tag/2.8.0.FINAL</docs.slee2.binary.url>
 		<docs.slee7.binary.url>https://github.com/RestComm/jain-slee/releases/latest</docs.slee7.binary.url>

--- a/docs/userguide/sources-asciidoc/src/main/asciidoc/Section-Managing-TCAP.adoc
+++ b/docs/userguide/sources-asciidoc/src/main/asciidoc/Section-Managing-TCAP.adoc
@@ -419,3 +419,47 @@ EXAMPLES
 
 On TCAP management page, click on pencil against the 'Statistics Enabled' property and text box becomes editable.
 Change value and save. 
+
+[[_tcap_property_slsrange]]
+=== SLS Range
+
+[[_tcap_property_slsrange_cli]]
+==== Using CLI
+
+You can set the 'slsrange' by issuing the command `tcap set slsrange` with appropriate parameters as described below.
+You can verify this by issuing the command `tcap get slsrange` which will display the value set for this property. 
+
+----
+
+Name
+	tcap set slsrange
+
+SYNOPSIS
+	tcap set slsrange <0 | 1 | 2> stackname <stack-name>
+
+DESCRIPTION
+	slsRanger: set the value of SLS to odd or even or both.
+
+PARAMETERS
+
+	Standard Parameters
+
+	<0>	-	If set to 0, SLS number can be odd or even value
+	<1>	-	If set to 1, SLS number can get only odd value
+	<2>	-	If set to 2, SLS number can get only even value
+
+	Optional Parameters
+
+	<stack-name>	-	Name of the stack on which this command is executed.
+					If not passed, the first stack configured in ShellExecutor
+					will be used.
+
+EXAMPLES
+	tcap set slsrange 0
+----
+
+[[_tcap_property_slsrange_gui]]
+==== Using GUI
+
+On TCAP management page, click on pencil against the 'SLS Range' property and text box becomes editable.
+Change value and save. 

--- a/oam/common/tcap/src/main/java/org/mobicents/protocols/ss7/oam/common/tcap/TcapManagementJmx.java
+++ b/oam/common/tcap/src/main/java/org/mobicents/protocols/ss7/oam/common/tcap/TcapManagementJmx.java
@@ -191,6 +191,16 @@ public class TcapManagementJmx implements TcapManagementJmxMBean, CounterMediato
     }
 
     @Override
+    public void setSlsRange(int val) throws Exception{
+        this.wrappedTCAPStack.setSlsRange(val);
+    }
+
+    @Override
+    public int getSlsRange() {
+        return this.wrappedTCAPStack.getSlsRange();
+    }
+
+    @Override
     public void setStatisticsEnabled(boolean val) throws Exception {
         this.wrappedTCAPStack.setStatisticsEnabled(val);
     }

--- a/oam/new-ui/src/main/webapp/modules/tcap.html
+++ b/oam/new-ui/src/main/webapp/modules/tcap.html
@@ -123,6 +123,7 @@
 												var doNotSendProtocolVersion = response.value.DoNotSendProtocolVersion;
 												var statisticsEnabled = response.value.StatisticsEnabled;
 												var ssn = response.value.SubSystemNumber;
+												var slsRange = response.value.SlsRange;
 												
 												var isTcapStarted = response.value.Started;
 												
@@ -293,7 +294,22 @@
 																			'</td>'+
 																		    '</tr>'+																		    
 														
-														
+																			'<tr data-toggle="tooltip" title="if set to 0, SLS value can get both odd or even numbers. If set to 1, SLS value can get only odd numbers. If set to 2, SLS value can get only even numbers.">'+
+																			'<td style="vertical-align: middle; text-align: center;">&nbsp;<i style="color: #CC9522;" class="icon-resize-small"></i></td>'+
+																			'<td style="font-size: 0.9em;">SLS Range</td>'+
+																			'<td style="font-size: 0.9em; padding: 0;">'+
+																				'<div id="div-' + name +'slsRange-input" class="control-group">'+
+																				'<span id="' + name +'slsRange-input" style="display: none;">'+
+																					'<input type="text" class="input-small" value="' + slsRange + '" /> ' +
+																					'<i class="icon-ok" style="cursor: pointer;" onclick="onSipServrConfigOk(\'' + name+ '\', \'SlsRange\', \'' + name+"slsRange" + '\')"></i> ' +
+																					'<i class="icon-remove" style="cursor: pointer;" onclick="$(\'[id^='+name+"slsRange"+']\').toggle(); $(\'input[id^='+name+"slsRange"+']\').focus();"></i>' + 
+																				'</span>'+
+																				'</div>' +
+																				'<span id="' +name + 'slsRange-text">' + slsRange + '</span>'+
+																			'</td>'+
+																			'<td><i class="icon-pencil" data-toggle="tooltip" title="Edit" style="cursor: pointer;" onclick="$(\'[id^='+name+"slsRange"+']\').toggle(); $(\'input[id^='+name+"slsRange"+']\').focus();"></i>' +
+																			'</td>'+
+																		    '</tr>'+															
 																														
 														'				</tbody>'+
 														'			</table>'+ 												

--- a/tcap-ansi/tcap-ansi-cli/src/main/java/org/mobicents/ss7/management/console/impl/TcapAnsiCommandHandler.java
+++ b/tcap-ansi/tcap-ansi-cli/src/main/java/org/mobicents/ss7/management/console/impl/TcapAnsiCommandHandler.java
@@ -42,6 +42,7 @@ public class TcapAnsiCommandHandler extends CommandHandlerWithHelp {
         set.addChild("dialogidrangeend");
 //        set.addChild("previewmode");
         set.addChild("statisticsenabled");
+        set.addChild("slsrange");
 
         Node get = parent.addChild("get");
         get.addChild("dialogidletimeout");
@@ -51,6 +52,7 @@ public class TcapAnsiCommandHandler extends CommandHandlerWithHelp {
         get.addChild("dialogidrangeend");
         get.addChild("previewmode");
         get.addChild("statisticsenabled");
+        get.addChild("slsrange");
 
     };
 

--- a/tcap-ansi/tcap-ansi-impl/src/main/java/org/mobicents/protocols/ss7/tcapAnsi/TCAPProviderImpl.java
+++ b/tcap-ansi/tcap-ansi-impl/src/main/java/org/mobicents/protocols/ss7/tcapAnsi/TCAPProviderImpl.java
@@ -182,6 +182,15 @@ public class TCAPProviderImpl implements TCAPProvider, SccpListener {
             seqControl = 0;
 
         }
+
+        if (this.stack.getSlsRange() == this.stack.SLS_RANGE_ODD) {
+            if (seqControl % 2 == 0)
+                seqControl+=1;
+        } else if (this.stack.getSlsRange() == this.stack.SLS_RANGE_EVEN) {
+            if (seqControl %2 != 0)
+                seqControl+=1;
+        }
+
         return seqControl;
     }
 

--- a/tcap-ansi/tcap-ansi-impl/src/main/java/org/mobicents/protocols/ss7/tcapAnsi/TCAPStackImpl.java
+++ b/tcap-ansi/tcap-ansi-impl/src/main/java/org/mobicents/protocols/ss7/tcapAnsi/TCAPStackImpl.java
@@ -62,6 +62,8 @@ public class TCAPStackImpl implements TCAPStack {
     private static final String DIALOG_ID_RANGE_END = "dialogidrangeend";
     private static final String PREVIEW_MODE = "previewmode";
     private static final String STATISTICS_ENABLED = "statisticsenabled";
+    private static final String SLS_RANGE = "slsrange";
+
 
     // default value of idle timeout and after TC_END remove of task.
     public static final long _DIALOG_TIMEOUT = 60000;
@@ -94,6 +96,11 @@ public class TCAPStackImpl implements TCAPStack {
     private long dialogIdRangeEnd = Integer.MAX_VALUE;
     private boolean previewMode = false;
     private boolean statisticsEnabled = false;
+
+    // SLS value
+    private int slsRange = 0;
+    public static final int SLS_RANGE_ODD = 1;
+    public static final int SLS_RANGE_EVEN = 2;
 
     public TCAPStackImpl(String name) {
         super();
@@ -334,6 +341,16 @@ public class TCAPStackImpl implements TCAPStack {
         return previewMode;
     }
 
+    public void setSlsRange(int slsRange) {
+        this.slsRange = slsRange;
+        this.store();
+
+    }
+
+    public int getSlsRange() {
+        return this.slsRange;
+    }
+
     @Override
     public void setStatisticsEnabled(boolean val) throws Exception {
         if (!this.started)
@@ -369,7 +386,10 @@ public class TCAPStackImpl implements TCAPStack {
             writer.write(this.dialogIdRangeStart, DIALOG_ID_RANGE_START, Long.class);
             writer.write(this.dialogIdRangeEnd, DIALOG_ID_RANGE_END, Long.class);
 
+
             writer.write(this.statisticsEnabled, STATISTICS_ENABLED, Boolean.class);
+
+            writer.write(this.slsRange, SLS_RANGE, Integer.class);
 
             writer.close();
         } catch (Exception e) {
@@ -401,9 +421,14 @@ public class TCAPStackImpl implements TCAPStack {
             if (vall != null)
                 this.dialogIdRangeEnd = vall;
 
+
             Boolean volb = reader.read(STATISTICS_ENABLED, Boolean.class);
             if (volb != null)
                 this.statisticsEnabled = volb;
+
+            vali = reader.read(SLS_RANGE, Integer.class);
+            if (vali != null)
+                this.slsRange = vali;
 
             reader.close();
         } catch (XMLStreamException ex) {

--- a/tcap-ansi/tcap-ansi-impl/src/main/java/org/mobicents/protocols/ss7/tcapAnsi/oam/TCAPAnsiExecutor.java
+++ b/tcap-ansi/tcap-ansi-impl/src/main/java/org/mobicents/protocols/ss7/tcapAnsi/oam/TCAPAnsiExecutor.java
@@ -149,6 +149,9 @@ public class TCAPAnsiExecutor implements ShellExecutor {
         } else if (parName.equals("statisticsenabled")) {
             boolean val = Boolean.parseBoolean(options[4]);
             tcapStackImpl.setStatisticsEnabled(val);
+        }else if (parName.equals("slsranger")) {
+            int val = Integer.parseInt(options[3]);
+            tcapStackImpl.setSlsRange(val);
         } else {
             return TCAPAnsiOAMMessage.INVALID_COMMAND;
         }
@@ -196,6 +199,8 @@ public class TCAPAnsiExecutor implements ShellExecutor {
                 sb.append(tcapStackImpl.getPreviewMode());
             } else if (parName.equals("statisticsenabled")) {
                 sb.append(tcapStackImpl.getStatisticsEnabled());
+            }else if (parName.equals("slsrange")) {
+                sb.append(tcapStackImpl.getSlsRange());
             } else {
                 return TCAPAnsiOAMMessage.INVALID_COMMAND;
             }
@@ -243,6 +248,11 @@ public class TCAPAnsiExecutor implements ShellExecutor {
                 sb.append("statisticsenabled = ");
                 sb.append(tcapStackImpl.getStatisticsEnabled());
                 sb.append("\n");
+
+                sb.append("slsrange = ");
+                sb.append(tcapStackImpl.getSlsRange());
+                sb.append("\n");
+
                 sb.append("*******************");
                 sb.append("\n");
                 sb.append("\n");

--- a/tcap/tcap-api/src/main/java/org/mobicents/protocols/ss7/tcap/api/TCAPStack.java
+++ b/tcap/tcap-api/src/main/java/org/mobicents/protocols/ss7/tcap/api/TCAPStack.java
@@ -165,4 +165,18 @@ public interface TCAPStack {
      */
     int getSubSystemNumber();
 
+    /**
+     * Set value for slsRange for this TCAP Stack.
+     *
+     * @param val
+     */
+    void setSlsRange(int val) throws Exception;
+
+    /**
+     * Returns the SlsRange that this TCAP Stack is registered for
+     *
+     * @return
+     */
+    int getSlsRange();
+
 }

--- a/tcap/tcap-cli/src/main/java/org/mobicents/ss7/management/console/impl/TcapCommandHandler.java
+++ b/tcap/tcap-cli/src/main/java/org/mobicents/ss7/management/console/impl/TcapCommandHandler.java
@@ -45,6 +45,7 @@ public class TcapCommandHandler extends CommandHandlerWithHelp {
 //        set.addChild("previewmode");
         set.addChild("donotsendprotocolversion");
         set.addChild("statisticsenabled");
+        set.addChild("slsrange");
 
         Node get = parent.addChild("get");
         get.addChild("dialogidletimeout");
@@ -56,6 +57,7 @@ public class TcapCommandHandler extends CommandHandlerWithHelp {
         get.addChild("donotsendprotocolversion");
         get.addChild("statisticsenabled");
         get.addChild("ssn");
+        get.addChild("slsrange");
 
     };
 

--- a/tcap/tcap-cli/src/main/resources/help/tcap_get_slsrange.txt
+++ b/tcap/tcap-cli/src/main/resources/help/tcap_get_slsrange.txt
@@ -1,0 +1,19 @@
+Name
+	tcap get slsrange
+
+SYNOPSIS
+	tcap get slsrange stackname <stack-name>
+
+DESCRIPTION
+	Gets value for slsrange.
+
+PARAMETERS
+
+	Optional Parameters
+
+	<stack-name>	-	Name of the stack on which this command is executed.
+					If not passed, the first stack configured in ShellExecutor
+					will be used.
+
+EXAMPLES
+	tcap get slsrange

--- a/tcap/tcap-cli/src/main/resources/help/tcap_set_slsrange.txt
+++ b/tcap/tcap-cli/src/main/resources/help/tcap_set_slsrange.txt
@@ -1,0 +1,25 @@
+Name
+	tcap set slsrange
+
+SYNOPSIS
+	tcap set slsrange <0 | 1 | 2> stackname <stack-name>
+
+DESCRIPTION
+	slsRanger: set the value of SLS to odd or even or both.
+
+PARAMETERS
+
+	Standard Parameters
+
+	<0>	-	If set to 0, SLS number can be odd or even value
+	<1>	-	If set to 1, SLS number can get only odd value
+	<2>	-	If set to 2, SLS number can get only even value
+
+	Optional Parameters
+
+	<stack-name>	-	Name of the stack on which this command is executed.
+					If not passed, the first stack configured in ShellExecutor
+					will be used.
+
+EXAMPLES
+	tcap set slsrange 0

--- a/tcap/tcap-impl/src/main/java/org/mobicents/protocols/ss7/tcap/TCAPProviderImpl.java
+++ b/tcap/tcap-impl/src/main/java/org/mobicents/protocols/ss7/tcap/TCAPProviderImpl.java
@@ -180,11 +180,21 @@ public class TCAPProviderImpl implements TCAPProvider, SccpListener {
 
     // get next Seq Control value available
     private synchronized int getNextSeqControl() {
+
         seqControl++;
         if (seqControl > 255) {
             seqControl = 0;
 
         }
+
+        if (this.stack.getSlsRange() == this.stack.SLS_RANGE_ODD) {
+            if (seqControl % 2 == 0)
+                seqControl+=1;
+        } else if (this.stack.getSlsRange() == this.stack.SLS_RANGE_EVEN) {
+            if (seqControl %2 != 0)
+                seqControl+=1;
+        }
+
         return seqControl;
     }
 

--- a/tcap/tcap-impl/src/main/java/org/mobicents/protocols/ss7/tcap/TCAPStackImpl.java
+++ b/tcap/tcap-impl/src/main/java/org/mobicents/protocols/ss7/tcap/TCAPStackImpl.java
@@ -63,6 +63,7 @@ public class TCAPStackImpl implements TCAPStack {
     private static final String PREVIEW_MODE = "previewmode";
     private static final String DO_NOT_SEND_PROTOCOL_VERSION = "donotsendprotocolversion";
     private static final String STATISTICS_ENABLED = "statisticsenabled";
+    private static final String SLS_RANGE = "slsrange";
 
 
     private static final XMLBinding binding = new XMLBinding();
@@ -99,6 +100,11 @@ public class TCAPStackImpl implements TCAPStack {
     private boolean statisticsEnabled = false;
 
     private int ssn = -1;
+
+    // SLS value
+    private int slsRange = 0;
+    public static final int SLS_RANGE_ODD = 1;
+    public static final int SLS_RANGE_EVEN = 2;
 
     public TCAPStackImpl(String name) {
         super();
@@ -348,6 +354,20 @@ public class TCAPStackImpl implements TCAPStack {
         return previewMode;
     }
 
+    public void setSlsRange(int val) throws Exception  {
+
+        if (val < 0 || val > 2) {
+            throw new Exception("SlsRange value is invalid");
+        }
+
+        this.slsRange = val;
+        this.store();
+    }
+
+    public int getSlsRange() {
+        return this.slsRange;
+    }
+
     @Override
     public void setDoNotSendProtocolVersion(boolean val) throws Exception {
         if (!this.started)
@@ -407,6 +427,9 @@ public class TCAPStackImpl implements TCAPStack {
 
             writer.write(this.statisticsEnabled, STATISTICS_ENABLED, Boolean.class);
 
+            writer.write(this.slsRange, SLS_RANGE, Integer.class);
+
+
             writer.close();
         } catch (Exception e) {
             this.logger.error(
@@ -448,6 +471,10 @@ public class TCAPStackImpl implements TCAPStack {
             volb = reader.read(STATISTICS_ENABLED, Boolean.class);
             if (volb != null)
                 this.statisticsEnabled = volb;
+
+            vali = reader.read(SLS_RANGE, Integer.class);
+            if (vali != null)
+                this.slsRange = vali;
 
             reader.close();
         } catch (XMLStreamException ex) {

--- a/tcap/tcap-impl/src/main/java/org/mobicents/protocols/ss7/tcap/oam/TCAPExecutor.java
+++ b/tcap/tcap-impl/src/main/java/org/mobicents/protocols/ss7/tcap/oam/TCAPExecutor.java
@@ -184,7 +184,11 @@ public class TCAPExecutor implements ShellExecutor {
         } else if (parName.equals("statisticsenabled")) {
             boolean val = Boolean.parseBoolean(options[3]);
             this.tcapStack.setStatisticsEnabled(val);
-        } else {
+        } else if (parName.equals("slsrange")) {
+            int val = Integer.parseInt(options[3]);
+            this.tcapStack.setSlsRange(val);
+        }
+        else {
             return TCAPOAMMessage.INVALID_COMMAND;
         }
 
@@ -230,7 +234,10 @@ public class TCAPExecutor implements ShellExecutor {
                 sb.append(this.tcapStack.getStatisticsEnabled());
             } else if (parName.equals("ssn")) {
                 sb.append(this.tcapStack.getSubSystemNumber());
-            } else {
+            } else if (parName.equals("slsrange")) {
+                sb.append(this.tcapStack.getSlsRange());
+            }
+            else {
                 return TCAPOAMMessage.INVALID_COMMAND;
             }
 
@@ -284,6 +291,11 @@ public class TCAPExecutor implements ShellExecutor {
                 sb.append("subsystemnumber = ");
                 sb.append(tcapStackImpl.getSubSystemNumber());
                 sb.append("\n");
+
+                sb.append("slsrange = ");
+                sb.append(tcapStackImpl.getSlsRange());
+                sb.append("\n");
+
                 sb.append("*******************");
                 sb.append("\n");
                 sb.append("\n");


### PR DESCRIPTION
    - Adding slsrange to TCAP
        - If slsrange set to 0 then SLS value can get both odd and even numbers
        - If slsrange set to 1 then SLS value can get only odd numbers
        - If slsrange set to 2 then SLS value can get only even numbers

    - Tested:
        - modify/update value by cli/gui
        - send new dialog with only SLS odd or even numbers

[sls_patch_non_netty.patch.txt](https://github.com/RestComm/jss7/files/918858/sls_patch_non_netty.patch.txt)

