### PR TITLE
Added code for using callingparty match in SCCP rules

### DIFF
--- a/map/load/src/main/java/org/mobicents/protocols/ss7/map/load/Client.java
+++ b/map/load/src/main/java/org/mobicents/protocols/ss7/map/load/Client.java
@@ -221,9 +221,9 @@ public class Client extends TestHarness {
                 NatureOfAddress.INTERNATIONAL);
         SccpAddress pattern = new SccpAddressImpl(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, gt, 0, 0);
         this.sccpStack.getRouter().addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.REMOTE, pattern,
-                "K", 1, -1, null, 0);
+                "K", 1, -1, null, 0, null, "K");
         this.sccpStack.getRouter().addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern,
-                "K", 2, -1, null, 0);
+                "K", 2, -1, null, 0, null, "K");
     }
 
     private void initTCAP() throws Exception {

--- a/map/load/src/main/java/org/mobicents/protocols/ss7/map/load/Server.java
+++ b/map/load/src/main/java/org/mobicents/protocols/ss7/map/load/Server.java
@@ -211,9 +211,9 @@ public class Server extends TestHarness {
                 NatureOfAddress.INTERNATIONAL);
         SccpAddress pattern = new SccpAddressImpl(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, gt, 0, 0);
         this.sccpStack.getRouter().addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.REMOTE, pattern,
-                "K", 1, -1, null, 0);
+                "K", 1, -1, null, 0, null, "");
         this.sccpStack.getRouter().addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern,
-                "K", 2, -1, null, 0);
+                "K", 2, -1, null, 0, null, "");
     }
 
     private void initTCAP() throws Exception {

--- a/sccp/sccp-api/src/main/java/org/mobicents/protocols/ss7/sccp/Router.java
+++ b/sccp/sccp-api/src/main/java/org/mobicents/protocols/ss7/sccp/Router.java
@@ -21,9 +21,9 @@
  */
 package org.mobicents.protocols.ss7.sccp;
 
-import java.util.Map;
-
 import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
+
+import java.util.Map;
 
 /**
  *
@@ -71,10 +71,12 @@ public interface Router {
     Map<Integer, LongMessageRule> getLongMessageRules();
 
     void addRule(int id, RuleType ruleType, LoadSharingAlgorithm algo, OriginationType originationType, SccpAddress pattern, String mask, int pAddressId,
-            int sAddressId, Integer newCallingPartyAddressAddressId, int networkId) throws Exception;
+            int sAddressId, Integer newCallingPartyAddressAddressId, int networkId, SccpAddress patternCallingAddress,
+                 String maskCallingAddress) throws Exception;
 
     void modifyRule(int id, RuleType ruleType, LoadSharingAlgorithm algo, OriginationType originationType, SccpAddress pattern, String mask, int pAddressId,
-            int sAddressId, Integer newCallingPartyAddressAddressId, int networkId) throws Exception;
+            int sAddressId, Integer newCallingPartyAddressAddressId, int networkId, SccpAddress patternCallingAddress,
+                    String maskCallingAddress) throws Exception;
 
     Rule getRule(int id);
 

--- a/sccp/sccp-api/src/main/java/org/mobicents/protocols/ss7/sccp/Rule.java
+++ b/sccp/sccp-api/src/main/java/org/mobicents/protocols/ss7/sccp/Rule.java
@@ -50,8 +50,11 @@ public interface Rule {
 
     int getNetworkId();
 
+    SccpAddress getPatternCallingAddress();
+
     boolean matches(SccpAddress address, boolean isMtpOriginated, int msgNetworkId);
 
     SccpAddress translate(SccpAddress address, SccpAddress ruleAddress);
+
 
 }

--- a/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/oam/SccpExecutor.java
+++ b/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/oam/SccpExecutor.java
@@ -22,12 +22,7 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.oam;
 
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Set;
-
 import javolution.util.FastMap;
-
 import org.apache.log4j.Logger;
 import org.mobicents.protocols.ss7.indicator.AddressIndicator;
 import org.mobicents.protocols.ss7.indicator.NatureOfAddress;
@@ -50,6 +45,10 @@ import org.mobicents.protocols.ss7.sccp.impl.parameter.SccpAddressImpl;
 import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle;
 import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
 import org.mobicents.ss7.management.console.ShellExecutor;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
 
 /**
  *
@@ -741,7 +740,8 @@ public class SccpExecutor implements ShellExecutor {
      * sccp rule create <id> <mask> <address-indicator> <point-code> <subsystem-number> <translation-type> <numbering-plan>
      * <nature-of-address-indicator> <digits> <ruleType> <primary-address-id> backup-addressid <backup-address-id>
      * loadsharing-algo <loadsharing-algorithm> newcgparty-addressid <new-callingPartyAddress-id> origination-type
-     * <originationType> stackname <stack-name>
+     * <originationType> calling-ai <address-indicator> calling-pc <point-code> calling-ssn <calling-subsystem-number> calling-tt <calling-translation-type> calling-np<calling-numbering-plan>
+     * calling-nai <calling-nature-of-address-indicator> mask-calling<callingAddress-mask> mask-calling-digits<calling-digits> stackname <stack-name>
      * </p>
      *
      * @param options
@@ -782,6 +782,16 @@ public class SccpExecutor implements ShellExecutor {
         OriginationType originationType = OriginationType.ALL;
         int networkId = 0;
 
+        // Calling Address fields with default values
+        int callingAI = 19;
+        int callingPC = -1;
+        int callingSSN = -1;
+        int callingTT = 0;
+        int callingNP = 1;
+        int callingNAI = 4;
+        String callingMask = "K";
+        String callingDigits = null; // having it null means no matching for callingSccpAddress
+
         while (count < options.length) {
             String key = options[count++];
             if (key == null) {
@@ -807,8 +817,24 @@ public class SccpExecutor implements ShellExecutor {
 
                 this.sccpStack = sccpStaclImpl;
             } else if (key.equals("networkid")) {
-                String networkIdS = options[count++];
-                networkId = Integer.parseInt(networkIdS);
+                String networkIdS = options[ count++ ];
+                networkId = Integer.parseInt( networkIdS );
+            } else if (key.equals( "calling-ai" )) {
+                callingAI = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-pc" )) {
+                callingPC = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-ssn" )) {
+                callingSSN = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-tt" )) {
+                callingTT = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-np" )) {
+                callingNP = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-nai" )) {
+                callingNAI = Integer.parseInt( options[count++] );
+            } else if (key.equals( "mask-calling" )) {
+                callingMask = options[count++];
+            } else if (key.equals( "mask-calling-digits" )) {
+                callingDigits = options[count++];
             } else {
                 return SccpOAMMessage.INVALID_COMMAND;
             }
@@ -816,9 +842,14 @@ public class SccpExecutor implements ShellExecutor {
 
         this.setDefaultValue();
         SccpAddress pattern = this.createAddress(options, 5, true);
+        SccpAddress callingPattern  = null;
+        if ( callingDigits == null ) {
+            callingPattern = this.createAddress( callingAI, callingPC, callingSSN, callingTT, callingNP, callingNAI, callingDigits, true );
+        }
 
-        this.sccpStack.getRouter().addRule(ruleId, ruleType, algo, originationType, pattern, mask, pAddressId, sAddressId,
-                newcgpartyAddressId, networkId);
+        this.sccpStack.getRouter().addRule( ruleId, ruleType, algo, originationType, pattern, mask, pAddressId, sAddressId,
+                newcgpartyAddressId, networkId, callingPattern, callingMask );
+
         return String.format(SccpOAMMessage.RULE_SUCCESSFULLY_ADDED, this.sccpStack.getName());
     }
 
@@ -858,6 +889,16 @@ public class SccpExecutor implements ShellExecutor {
         OriginationType originationType = OriginationType.ALL;
         int networkId = 0;
 
+        // Calling Address fields with default values
+        int callingAI = 19;
+        int callingPC = -1;
+        int callingSSN = -1;
+        int callingTT = 0;
+        int callingNP = 1;
+        int callingNAI = 4;
+        String callingMask = "K";
+        String callingDigits = null;
+
         while (count < options.length) {
             String key = options[count++];
             if (key == null) {
@@ -885,15 +926,36 @@ public class SccpExecutor implements ShellExecutor {
             } else if (key.equals("networkid")) {
                 String networkIdS = options[count++];
                 networkId = Integer.parseInt(networkIdS);
-            } else {
+            } else if (key.equals( "calling-ai" )) {
+                callingAI = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-pc" )) {
+                callingPC = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-ssn" )) {
+                callingSSN = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-tt" )) {
+                callingTT = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-np" )) {
+                callingNP = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-nai" )) {
+                callingNAI = Integer.parseInt( options[count++] );
+            } else if (key.equals( "mask-calling" )) {
+                callingMask = options[count++];
+            } else if (key.equals( "mask-calling-digits" )) {
+                callingDigits = options[count++];
+            }  else {
                 return SccpOAMMessage.INVALID_COMMAND;
             }
         }
 
         this.setDefaultValue();
         SccpAddress pattern = this.createAddress(options, 5, true);
+        SccpAddress callingPattern  = null;
+        if ( callingDigits == null ) {
+            callingPattern = this.createAddress( callingAI, callingPC, callingSSN, callingTT, callingNP, callingNAI, callingDigits, true );
+        }
+
         this.sccpStack.getRouter().modifyRule(ruleId, ruleType, algo, originationType, pattern, mask, pAddressId, sAddressId,
-                newcgpartyAddressId, networkId);
+                newcgpartyAddressId, networkId, callingPattern, callingMask);
         return String.format(SccpOAMMessage.RULE_SUCCESSFULLY_MODIFIED, this.sccpStack.getName());
     }
 
@@ -1016,15 +1078,15 @@ public class SccpExecutor implements ShellExecutor {
 
         // sccp address create <id> <address-indicator> <point-code> <subsystemnumber> <translation-type> <numbering-plan>
         // <nature-of-address-indicator> <digits>
+        return createAddress(Integer.parseInt(options[index++]), Integer.parseInt(options[index++]), Integer.parseInt(options[index++]),
+                Integer.parseInt(options[index++]), Integer.parseInt(options[index++]), Integer.parseInt(options[index++]),
+                options[index++], isRule);
+    }
+
+    private SccpAddress createAddress(int ai, int pc, int ssn, int tt, int npValue, int naiValue, String digits, boolean isRule) throws Exception {
         SccpAddress sccpAddress = null;
 
-        int ai = Integer.parseInt(options[index++]);
-        int pc = 0;
-        int ssn = 0;
-
         AddressIndicator aiObj = new AddressIndicator((byte) ai, SccpProtocolVersion.ITU);
-        pc = Integer.parseInt(options[index++]);
-        ssn = Integer.parseInt(options[index++]);
 
 //        if (aiObj.isSSNPresent() && ssn == 0) {
 //            throw new Exception(
@@ -1040,11 +1102,8 @@ public class SccpExecutor implements ShellExecutor {
             throw new Exception(String.format("Point code parameter is mandatory and must be > 0"));
         }
 
-        int tt = Integer.parseInt(options[index++]);
-        NumberingPlan np = NumberingPlan.valueOf(Integer.parseInt(options[index++]));
-        NatureOfAddress nai = NatureOfAddress.valueOf(Integer.parseInt(options[index++]));
-
-        String digits = options[index++];
+        NumberingPlan np = NumberingPlan.valueOf(npValue);
+        NatureOfAddress nai = NatureOfAddress.valueOf(naiValue);
 
         GlobalTitle gt = null;
 

--- a/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RouterImpl.java
+++ b/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RouterImpl.java
@@ -22,25 +22,12 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.router;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.StringReader;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-
 import javolution.text.TextBuilder;
 import javolution.util.FastMap;
 import javolution.xml.XMLBinding;
 import javolution.xml.XMLObjectReader;
 import javolution.xml.XMLObjectWriter;
 import javolution.xml.stream.XMLStreamException;
-
 import org.apache.log4j.Logger;
 import org.mobicents.protocols.ss7.sccp.LoadSharingAlgorithm;
 import org.mobicents.protocols.ss7.sccp.LongMessageRule;
@@ -63,6 +50,18 @@ import org.mobicents.protocols.ss7.sccp.impl.parameter.GlobalTitle0100Impl;
 import org.mobicents.protocols.ss7.sccp.impl.parameter.NoGlobalTitle;
 import org.mobicents.protocols.ss7.sccp.impl.parameter.SccpAddressImpl;
 import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.StringReader;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * <p>
@@ -386,7 +385,8 @@ public class RouterImpl implements Router {
     }
 
     public void addRule(int id, RuleType ruleType, LoadSharingAlgorithm algo, OriginationType originationType, SccpAddress pattern, String mask,
-            int pAddressId, int sAddressId, Integer newCallingPartyAddressAddressId, int networkId) throws Exception {
+            int pAddressId, int sAddressId, Integer newCallingPartyAddressAddressId, int networkId, SccpAddress patternCallingAddress,
+                        String maskCallingAddress) throws Exception {
 
         Rule ruleTmp = this.getRule(id);
 
@@ -428,7 +428,7 @@ public class RouterImpl implements Router {
         }
 
         synchronized (this) {
-            RuleImpl rule = new RuleImpl(ruleType, algo, originationType, pattern, mask, networkId);
+            RuleImpl rule = new RuleImpl(ruleType, algo, originationType, pattern, mask, networkId, patternCallingAddress, maskCallingAddress);
             rule.setPrimaryAddressId(pAddressId);
             rule.setSecondaryAddressId(sAddressId);
             rule.setNewCallingPartyAddressId(newCallingPartyAddressAddressId);
@@ -461,7 +461,8 @@ public class RouterImpl implements Router {
     }
 
     public void modifyRule(int id, RuleType ruleType, LoadSharingAlgorithm algo, OriginationType originationType, SccpAddress pattern, String mask,
-            int pAddressId, int sAddressId, Integer newCallingPartyAddressAddressId, int networkId) throws Exception {
+            int pAddressId, int sAddressId, Integer newCallingPartyAddressAddressId, int networkId, SccpAddress patternCallingAddress,
+                           String maskCallingAddress) throws Exception {
         Rule ruleTmp = this.getRule(id);
 
         if (ruleTmp == null) {
@@ -500,7 +501,7 @@ public class RouterImpl implements Router {
             throw new Exception(SccpOAMMessage.RULETYPE_NOT_SOLI_SEC_ADD_MANDATORY);
         }
         synchronized (this) {
-            RuleImpl rule = new RuleImpl(ruleType, algo, originationType, pattern, mask, networkId);
+            RuleImpl rule = new RuleImpl(ruleType, algo, originationType, pattern, mask, networkId, patternCallingAddress, maskCallingAddress);
             rule.setPrimaryAddressId(pAddressId);
             rule.setSecondaryAddressId(sAddressId);
             rule.setNewCallingPartyAddressId(newCallingPartyAddressAddressId);

--- a/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleImpl.java
+++ b/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleImpl.java
@@ -22,12 +22,9 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.router;
 
-import java.io.Serializable;
-
 import javolution.text.CharArray;
 import javolution.xml.XMLFormat;
 import javolution.xml.stream.XMLStreamException;
-
 import org.apache.log4j.Logger;
 import org.mobicents.protocols.ss7.indicator.GlobalTitleIndicator;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
@@ -50,6 +47,8 @@ import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle0010;
 import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle0011;
 import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle0100;
 import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
+
+import java.io.Serializable;
 
 /**
  * @author amit bhayani
@@ -86,6 +85,8 @@ public class RuleImpl implements Rule, Serializable {
     private static final String SECONDARY_ADDRESS = "saddress";
     private static final String NEW_CALLING_PARTY_ADDRESS = "ncpaddress";
     private static final String MASK = "mask";
+    private static final String MASK_CALLING_ADDRESS = "maskCallingAddress";
+    private static final String PATTERN_CALLING_ADDRESS = "patternCallingAddress";
 
     private static final String SEPARATOR = ";";
 
@@ -95,6 +96,7 @@ public class RuleImpl implements Rule, Serializable {
 
     /** Pattern used for selecting rule */
     private SccpAddress pattern;
+    private SccpAddress patternCallingAddress;
 
     private int ruleId;
 
@@ -108,6 +110,10 @@ public class RuleImpl implements Rule, Serializable {
 
     private String[] maskPattern = null;
 
+    private String maskCallingAddress = null;
+
+    private String[] maskCallignSccpAddressPattern = null;
+
     public static final int MIN_SIGNIFICANT_SSN = 1;
     public static final int MAX_SIGNIFICANT_SSN = 255;
 
@@ -119,14 +125,18 @@ public class RuleImpl implements Rule, Serializable {
      * Creates new routing rule.
      *
      */
-    public RuleImpl(RuleType ruleType, LoadSharingAlgorithm loadSharingAlgo, OriginationType originationType,
-            SccpAddress pattern, String mask, int networkId) {
+    public RuleImpl( RuleType ruleType, LoadSharingAlgorithm loadSharingAlgo, OriginationType originationType,
+                     SccpAddress pattern, String mask, int networkId, SccpAddress patternCallingAddress, String maskCallingAddress ) {
         this.ruleType = ruleType;
         this.pattern = pattern;
         this.mask = mask;
         this.networkId = networkId;
         this.setLoadSharingAlgorithm(loadSharingAlgo);
         this.setOriginationType(originationType);
+
+        // Calling SCCP Address
+        this.patternCallingAddress = patternCallingAddress;
+        this.maskCallingAddress = maskCallingAddress;
 
         configure();
     }
@@ -185,6 +195,7 @@ public class RuleImpl implements Rule, Serializable {
 
     private void configure() {
         this.maskPattern = this.mask.split("/");
+        this.maskCallignSccpAddressPattern = this.maskCallingAddress.split("/");
     }
 
     public int getPrimaryAddressId() {
@@ -217,6 +228,10 @@ public class RuleImpl implements Rule, Serializable {
 
     public void setNetworkId(int networkId) {
         this.networkId = networkId;
+    }
+
+    public SccpAddress getPatternCallingAddress() {
+        return patternCallingAddress;
     }
 
     /**

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/congestion/CongestionLevelTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/congestion/CongestionLevelTest.java
@@ -22,15 +22,7 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.congestion;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Properties;
-
 import javolution.util.FastMap;
-
 import org.mobicents.protocols.ss7.indicator.NatureOfAddress;
 import org.mobicents.protocols.ss7.indicator.NumberingPlan;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
@@ -63,6 +55,13 @@ import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
 import org.mobicents.ss7.congestion.ExecutorCongestionMonitor;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Properties;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author Sergey Vetyutnev
@@ -107,7 +106,7 @@ public class CongestionLevelTest {
                 NatureOfAddress.INTERNATIONAL);
         SccpAddress sccpAddress1 = new SccpAddressImpl(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, gt1, 101, 8);
         router.addRoutingAddress(1, sccpAddress1);
-        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.ALL, pattern, "K", 1, -1, null, 1);
+        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.ALL, pattern, "K", 1, -1, null, 1, pattern, "K");
 
         listenerProxy = new SccpListenerProxy();
         sccpStack.getSccpProvider().registerSccpListener(8, listenerProxy);

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/congestion/NetworkIdAffectedPCTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/congestion/NetworkIdAffectedPCTest.java
@@ -22,12 +22,7 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.congestion;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
 import javolution.util.FastMap;
-
 import org.mobicents.protocols.ss7.indicator.NatureOfAddress;
 import org.mobicents.protocols.ss7.indicator.NumberingPlan;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
@@ -47,6 +42,11 @@ import org.mobicents.protocols.ss7.sccp.impl.router.RouterImpl;
 import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle;
 import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author Sergey Vetyutnev
@@ -82,10 +82,10 @@ public class NetworkIdAffectedPCTest {
         router.addRoutingAddress(3, sccpAddress3);
         router.addRoutingAddress(4, sccpAddress4);
 
-        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.ALL, pattern, "K", 1, -1, null, 1);
-        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 2, -1, null, 2);
-        router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.REMOTE, pattern, "K", 3, -1, null, 3);
-        router.addRule(4, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.ALL, pattern, "K", 4, -1, null, 11);
+        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.ALL, pattern, "K", 1, -1, null, 1, pattern, "K");
+        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 2, -1, null, 2, pattern, "K");
+        router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.REMOTE, pattern, "K", 3, -1, null, 3, pattern, "K");
+        router.addRule(4, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.ALL, pattern, "K", 4, -1, null, 11, pattern, "K");
 
         map = router.getNetworkIdList(101);
         assertEquals(map.size(), 1);
@@ -124,7 +124,7 @@ public class NetworkIdAffectedPCTest {
         RemoteSignalingPointCodeImpl rspc2 = (RemoteSignalingPointCodeImpl) sccpStack.getSccpResource().getRemoteSpc(2);
 
         router.removeRule(2);
-        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 2, -1, null, 1);
+        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 2, -1, null, 1, pattern, "K");
         map = router.getNetworkIdList(101);
         assertEquals(map.size(), 1);
         state = map.get(1);
@@ -134,7 +134,7 @@ public class NetworkIdAffectedPCTest {
 
         sccpAddress2 = new SccpAddressImpl(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, gt1, 101, 8);
         router.removeRule(2);
-        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, -1, null, 1);
+        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, -1, null, 1, pattern, "K");
         map = router.getNetworkIdList(101);
         assertEquals(map.size(), 1);
         state = map.get(1);
@@ -148,8 +148,8 @@ public class NetworkIdAffectedPCTest {
         sccpAddress2 = new SccpAddressImpl(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, gt1, 102, 8);
         router.addRoutingAddress(1, sccpAddress1);
         router.addRoutingAddress(2, sccpAddress2);
-        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, -1, null, 1);
-        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 2, -1, null, 1);
+        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, -1, null, 1, pattern, "K");
+        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 2, -1, null, 1, pattern, "K");
         sccpStack.getSccpResource().addRemoteSpc(1, 101, 0, 0);
         sccpStack.getSccpResource().addRemoteSpc(2, 102, 0, 0);
         rspc1 = (RemoteSignalingPointCodeImpl) sccpStack.getSccpResource().getRemoteSpc(1);
@@ -196,7 +196,7 @@ public class NetworkIdAffectedPCTest {
         // Dominant
         router.removeRule(1);
         router.removeRule(2);
-        router.addRule(1, RuleType.DOMINANT, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, 2, null, 1);
+        router.addRule(1, RuleType.DOMINANT, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, 2, null, 1, pattern, "K");
         SccpRspProxy.setCurrentRestrictionLevel(rspc1, 0);
         SccpRspProxy.setRemoteSpcProhibited(rspc1, false);
         SccpRspProxy.setCurrentRestrictionLevel(rspc2, 0);
@@ -248,7 +248,7 @@ public class NetworkIdAffectedPCTest {
 
         // Loadsharing
         router.removeRule(1);
-        router.addRule(1, RuleType.LOADSHARED, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, 2, null, 1);
+        router.addRule(1, RuleType.LOADSHARED, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, 2, null, 1, pattern, "K");
         SccpRspProxy.setCurrentRestrictionLevel(rspc1, 0);
         SccpRspProxy.setRemoteSpcProhibited(rspc1, false);
         SccpRspProxy.setCurrentRestrictionLevel(rspc2, 0);
@@ -310,8 +310,8 @@ public class NetworkIdAffectedPCTest {
 
         // two affected networkIDs 
         router.removeRule(1);
-        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, -1, null, 1);
-        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 2, -1, null, 2);
+        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, -1, null, 1, pattern, "K");
+        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 2, -1, null, 2, pattern, "K");
         SccpRspProxy.setCurrentRestrictionLevel(rspc1, 4);
         SccpRspProxy.setRemoteSpcProhibited(rspc1, false);
         SccpRspProxy.setCurrentRestrictionLevel(rspc2, 2);

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/message/GetMaxUserDataLengthTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/message/GetMaxUserDataLengthTest.java
@@ -22,8 +22,6 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.message;
 
-import static org.testng.Assert.assertEquals;
-
 import org.mobicents.protocols.ss7.Util;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
 import org.mobicents.protocols.ss7.sccp.LoadSharingAlgorithm;
@@ -32,13 +30,13 @@ import org.mobicents.protocols.ss7.sccp.OriginationType;
 import org.mobicents.protocols.ss7.sccp.RuleType;
 import org.mobicents.protocols.ss7.sccp.impl.Mtp3UserPartImpl;
 import org.mobicents.protocols.ss7.sccp.impl.SccpStackImpl;
-import org.mobicents.protocols.ss7.sccp.impl.parameter.GlobalTitle0010Impl;
 import org.mobicents.protocols.ss7.sccp.impl.parameter.SccpAddressImpl;
-import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle;
 import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
 
 /**
  *
@@ -77,7 +75,7 @@ public class GetMaxUserDataLengthTest {
         stack.getRouter().addRoutingAddress(1, primaryAddress);
         SccpAddress pattern = new SccpAddressImpl(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, stack.getSccpProvider().getParameterFactory().createGlobalTitle("1122334455",0), 2, 18);
         stack.getRouter().addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 1,
-                -1, null, 0);
+                -1, null, 0, pattern, "K");
 
         int len = stack.getSccpProvider().getMaxUserDataLength(a1, a2, 0);
         assertEquals(len, 248);

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/messageflow/CallingPartyAddressTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/messageflow/CallingPartyAddressTest.java
@@ -22,10 +22,6 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.messageflow;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-
 import org.mobicents.protocols.ss7.Util;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
 import org.mobicents.protocols.ss7.sccp.LoadSharingAlgorithm;
@@ -42,6 +38,10 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  *
@@ -128,7 +128,7 @@ public class CallingPartyAddressTest extends SccpHarness {
                 RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 sccpProvider1.getParameterFactory().createGlobalTitle("111111", 1), 0, 0);
         sccpStack1.getRouter().addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K",
-                1, -1, null, 0);
+                1, -1, null, 0, pattern, "K");
 
         SccpAddress a3 = sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 sccpProvider1.getParameterFactory().createGlobalTitle("111111", 1), 0, 0);
@@ -145,7 +145,7 @@ public class CallingPartyAddressTest extends SccpHarness {
         // present newCallingPartyAddress
         sccpStack1.getRouter().removeRule(1);
         sccpStack1.getRouter().addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K",
-                1, -1, 2, 0);
+                1, -1, 2, 0, pattern, "K");
 
         message = this.sccpProvider1.getMessageFactory().createDataMessageClass1(a3, a1, getDataSrc(), 0, 8, true, null, null);
         sccpProvider1.send(message);

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/messageflow/LoadSharingTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/messageflow/LoadSharingTest.java
@@ -22,8 +22,6 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.messageflow;
 
-import static org.testng.Assert.assertEquals;
-
 import org.mobicents.protocols.ss7.Util;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
 import org.mobicents.protocols.ss7.sccp.LoadSharingAlgorithm;
@@ -41,6 +39,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
 
 /**
  * 
@@ -147,7 +147,7 @@ public class LoadSharingTest extends SccpHarness {
                 RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 sccpProvider1.getParameterFactory().createGlobalTitle("222222", 1), 0, 0);
         sccpStack1.getRouter().addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K",
-                1, -1, null, 0);
+                1, -1, null, 0,pattern, "K");
 
         // Primary and backup are available
         SccpAddress a3 = sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
@@ -204,7 +204,7 @@ public class LoadSharingTest extends SccpHarness {
         // ---- Dominant case
         sccpStack1.getRouter().removeRule(1);
         sccpStack1.getRouter().addRule(1, RuleType.DOMINANT, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K",
-                1, 3, null, 0);
+                1, 3, null, 0, pattern, "K");
 
         // Primary and backup are available
         a3 = sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
@@ -260,10 +260,10 @@ public class LoadSharingTest extends SccpHarness {
         // ---- Loadshared case
         sccpStack1.getRouter().removeRule(1);
         sccpStack1.getRouter().addRule(1, RuleType.LOADSHARED, LoadSharingAlgorithm.Bit4, OriginationType.ALL, pattern, "K", 1,
-                3, null, 0);
+                3, null, 0, pattern, "K");
         // rule which primaryAddress ssn==0 (getting ssn from origin CalledPartyAddress)
         sccpStack1.getRouter().addRule(2, RuleType.LOADSHARED, LoadSharingAlgorithm.Bit4, OriginationType.ALL, pattern2, "K",
-                2, 3, null, 0);
+                2, 3, null, 0, pattern2, "K");
 
         // Primary and backup are available
         // - class 1 (route by sls): sls = 0xEF: primary route (sls & 0x10 rule)
@@ -366,7 +366,7 @@ public class LoadSharingTest extends SccpHarness {
         sccpStack1.getRouter().removeRule(1);
         sccpStack1.getRouter().removeRule(2);
         sccpStack1.getRouter().addRule(1, RuleType.BROADCAST, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern,
-                "K", 1, 3, null, 0);
+                "K", 1, 3, null, 0, pattern,"K");
 
         // Primary and backup are available
         a3 = sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/NetworkIdTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/NetworkIdTest.java
@@ -22,10 +22,6 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.router;
 
-import static org.testng.Assert.*;
-
-import java.io.IOException;
-
 import org.apache.log4j.Logger;
 import org.mobicents.protocols.ss7.indicator.NatureOfAddress;
 import org.mobicents.protocols.ss7.indicator.NumberingPlan;
@@ -66,6 +62,10 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.testng.Assert.assertEquals;
 
 /**
  * 
@@ -157,10 +157,10 @@ public class NetworkIdTest implements SccpListener {
         router.addRoutingAddress(4, primaryAddr2_L);
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
-        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.LOCAL, pattern, "K", 1, 1, null, 1);
-        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.LOCAL, pattern, "K", 2, 2, null, 2);
-        router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.REMOTE, pattern, "K", 3, 3, null, 1);
-        router.addRule(4, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.REMOTE, pattern, "K", 4, 4, null, 2);
+        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.LOCAL, pattern, "K", 1, 1, null, 1, pattern, "K");
+        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.LOCAL, pattern, "K", 2, 2, null, 2, pattern, "K");
+        router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.REMOTE, pattern, "K", 3, 3, null, 1, pattern, "K");
+        router.addRule(4, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.REMOTE, pattern, "K", 4, 4, null, 2, pattern, "K");
         // int id, RuleType ruleType, LoadSharingAlgorithm algo, OriginationType
         // originationType, SccpAddress pattern, String mask, int pAddressId,
         // int sAddressId, Integer newCallingPartyAddressAddressId, int networkId

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RouterTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RouterTest.java
@@ -22,16 +22,7 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.router;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-
-import java.io.IOException;
-import java.util.Map;
-
 import javolution.util.FastMap;
-
 import org.mobicents.protocols.ss7.Util;
 import org.mobicents.protocols.ss7.indicator.GlobalTitleIndicator;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
@@ -64,6 +55,14 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author amit bhayani
@@ -129,10 +128,12 @@ public class RouterTest {
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("123456789",1),0, 0);
 
-        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R", 2, 2, null, 0);
+        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R", 2,
+                2, null, 0, pattern, "R");
         assertEquals(router.getRules().size(), 1);
 
-        router.addRule(2, RuleType.LOADSHARED, LoadSharingAlgorithm.Bit4, OriginationType.ALL, pattern, "K", 2, 2, null, 0);
+        router.addRule(2, RuleType.LOADSHARED, LoadSharingAlgorithm.Bit4, OriginationType.ALL, pattern, "K", 2,
+                2, null, 0, pattern, "K");
         assertEquals(router.getRules().size(), 2);
 
         router.removeRule(2);
@@ -179,10 +180,13 @@ public class RouterTest {
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 factory.createGlobalTitle("*", 1), 0, 0);
 
+        SccpAddress patternCallingAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("*", 1), 0, 0);
+
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_DPC_AND_SSN,
                 factory.createGlobalTitle("-"), 123, 146);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0, patternCallingAddress, "K");
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
@@ -208,10 +212,13 @@ public class RouterTest {
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 factory.createGlobalTitle("*", 1), 0, 146);
 
+        SccpAddress patternCallingAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("*", 1), 0, 0);
+
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_DPC_AND_SSN,
                 factory.createGlobalTitle("-"), 123, 146);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0, patternCallingAddress, "K");
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
@@ -236,8 +243,13 @@ public class RouterTest {
         router.addRoutingAddress(2, primaryAddr2);
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("123456789",1),0, 0);
+
+        String callingAddressDigits = "987654321";
+        SccpAddress patternCallingAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+               factory.createGlobalTitle(callingAddressDigits,1), 0, 0);
+
         router.addRule(1, RuleType.LOADSHARED, LoadSharingAlgorithm.Bit4, OriginationType.REMOTE, pattern, "K", 1, 2,
-                null, 6);
+                null, 6, patternCallingAddress, "K");
 
         router.addLongMessageRule(1, 1, 2, LongMessageRuleType.XUDT_ENABLED);
         router.addMtp3ServiceAccessPoint(3, 1, 11, 2, 5);
@@ -266,6 +278,7 @@ public class RouterTest {
         assertEquals(sap.getMtp3Destinations().size(), 1);
         assertEquals(sap.getNetworkId(), 5);
         assertEquals(dst.getLastDpc(), 110);
+        assertTrue(rl.getPatternCallingAddress().getGlobalTitle().getDigits().equals( callingAddressDigits ));
 
         router1.stop();
     }
@@ -283,7 +296,7 @@ public class RouterTest {
         SccpAddress pattern1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 factory.createGlobalTitle("800/????/9", 1), 0, 0);
         router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern1, "R/K/R", 1, -1,
-                null, 0);
+                null, 0, pattern1, "R/K/R");
 
         // Rule 2
         SccpAddress pattern2 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
@@ -292,7 +305,8 @@ public class RouterTest {
                 factory.createGlobalTitle("-", 1), 123, 0);
         router.addRoutingAddress(2, primaryAddr2);
 
-        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern2, "K", 2, -1, null, 0);
+        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern2, "K", 2, -1,
+                null, 0, pattern2, "K");
 
         // Rule 3
         SccpAddress pattern3 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
@@ -301,7 +315,7 @@ public class RouterTest {
                 factory.createGlobalTitle("-/-/-/-", 1), 123, 0);
         router.addRoutingAddress(3, primaryAddr3);
         router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern3, "K/K/K/K", 3, -1,
-                null, 0);
+                null, 0, pattern3, "K/K/K/K");
 
         // Rule 4
         SccpAddress pattern4 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("80/??/0/???/9", 1),0, 0);
@@ -309,7 +323,7 @@ public class RouterTest {
                  0);
         router.addRoutingAddress(4, primaryAddr4);
         router.addRule(4, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern4, "R/K/R/K/R", 4, -1,
-                null, 0);
+                null, 0, pattern4, "R/K/R/K/R");
 
         // Rule 5
         SccpAddress pattern5 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,factory.createGlobalTitle("800/?????/9", 1), 0,  0);
@@ -317,26 +331,29 @@ public class RouterTest {
                 0);
         router.addRoutingAddress(5, primaryAddr5);
         router.addRule(5, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern5, "R/K/R", 5, -1,
-                null, 0);
+                null, 0, pattern5, "R/K/R");
 
         // Rule 6
         SccpAddress pattern6 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("123456",1), 0, 0);
         SccpAddress primaryAddr6 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-", 1),123, 0);
         router.addRoutingAddress(6, primaryAddr6);
-        router.addRule(6, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern6, "K", 6, -1, null, 0);
+        router.addRule(6, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern6, "K", 6,
+                -1, null, 0, pattern6, "K");
 
         // Rule 7
         SccpAddress pattern7 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("1234567890", 1), 0, 0);
         SccpAddress primaryAddr7 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-", 1), 123, 0);
         router.addRoutingAddress(7, primaryAddr7);
-        router.addRule(7, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern7, "K", 7, -1, null, 0);
+        router.addRule(7, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern7, "K", 7,
+                -1, null, 0, pattern7, "K");
 
         // Rule 8
 
         SccpAddress pattern8 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("999/*", 1), 0, 0);
         SccpAddress primaryAddr8 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("111/-", 1), 123, 0);
         router.addRoutingAddress(8, primaryAddr8);
-        router.addRule(8, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern8, "R/K", 8, -1, null, 0);
+        router.addRule(8, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern8, "R/K", 8,
+                -1, null, 0, pattern8, "R/K");
 
         // TEST find rule
 
@@ -417,19 +434,21 @@ public class RouterTest {
         router.addRoutingAddress(1, primaryAddr1);
 
         SccpAddress pattern1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
-        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern1, "K", 1, -1, null, 0);
+        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern1, "K", 1,
+                -1, null, 0, pattern1, "*");
 
         // Rule 2
         router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.LOCAL, pattern1, "K", 1,
-                -1, null, 0);
+                -1, null, 0, pattern1, "K");
 
         // Rule 3
         SccpAddress pattern2 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("999", 1), 0, 0);
-        router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern2, "K", 1, -1, null, 0);
+        router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern2, "K", 1,
+                -1, null, 0, pattern2,"K");
 
         // Rule 4
         router.addRule(4, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.REMOTE, pattern2, "K",
-                1, -1, null, 0);
+                1, -1, null, 0, pattern2, "K");
 
         // TEST find rule
         boolean localOriginatedSign = false;

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleComparatorTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleComparatorTest.java
@@ -21,10 +21,6 @@
  */
 package org.mobicents.protocols.ss7.sccp.impl.router;
 
-import static org.testng.Assert.assertEquals;
-
-import java.util.Arrays;
-
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
 import org.mobicents.protocols.ss7.sccp.LoadSharingAlgorithm;
 import org.mobicents.protocols.ss7.sccp.OriginationType;
@@ -37,6 +33,10 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.testng.Assert.assertEquals;
 
 /**
  * @author amit bhayani
@@ -66,43 +66,43 @@ public class RuleComparatorTest {
     public void testSorting() throws Exception {
 
         SccpAddress pattern1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("800/????/9", 1), 0, 0);
-        RuleImpl rule1 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern1, "R/K/R", 0);
+        RuleImpl rule1 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern1, "R/K/R", 0, pattern1, "R/K/R");
 
         RuleImpl rule1a = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.LOCAL,
-                pattern1, "R/K/R", 0);
+                pattern1, "R/K/R", 0, pattern1, "R/K/R");
 
         SccpAddress pattern2 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
-        RuleImpl rule2 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern2, "K", 0);
+        RuleImpl rule2 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern2, "K", 0, pattern2, "K");
 
         RuleImpl rule2a = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.LOCAL,
-                pattern2, "K", 0);
+                pattern2, "K", 0, pattern2, "K");
 
         SccpAddress pattern3 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("9/?/9/*", 1), 0, 0);
         RuleImpl rule3 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern3,
-                "K/K/K/K", 0);
+                "K/K/K/K", 0, pattern3, "K/K/K/K");
 
         RuleImpl rule3a = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.REMOTE,
-                pattern3, "K/K/K/K", 0);
+                pattern3, "K/K/K/K", 0, pattern3, "K/K/K/K");
 
         SccpAddress pattern4 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("80/??/0/???/9", 1), 0, 0);
         RuleImpl rule4 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern4,
-                "R/K/R/K/R", 0);
+                "R/K/R/K/R", 0, pattern4, "R/K/R/K/R");
 
         SccpAddress pattern5 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("800/?????/9", 1), 0, 0);
-        RuleImpl rule5 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern5, "R/K/R", 0);
+        RuleImpl rule5 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern5, "R/K/R", 0, pattern5, "R/K/R");
 
         SccpAddress pattern6 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("123456", 1), 0, 0);
-        RuleImpl rule6 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern6, "K", 0);
+        RuleImpl rule6 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern6, "K", 0, pattern6, "K");
 
         SccpAddress pattern7 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("1234567890", 1), 0, 0);
-        RuleImpl rule7 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern7, "R/K/R", 0);
+        RuleImpl rule7 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern7, "R/K/R", 0, pattern7, "R/K/R");
 
         SccpAddress pattern8 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("999/*", 1), 0, 0);
-        RuleImpl rule8 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern8, "R/K", 0);
+        RuleImpl rule8 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern8, "R/K", 0, pattern8, "R/K");
         
 
         SccpAddress pattern9 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("9999/*", 1), 0, 0);
-        RuleImpl rule9 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern9, "R/K", 0);
+        RuleImpl rule9 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern9, "R/K", 0, pattern9, "R/K");
 
         // This is unsorted
         RuleImpl[] rules = new RuleImpl[] { rule1, rule2, rule3, rule4, rule5, rule6, rule7, rule8, rule1a, rule2a, rule3a, rule9 };

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleTest.java
@@ -22,19 +22,9 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.router;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-
 import javolution.xml.XMLBinding;
 import javolution.xml.XMLObjectReader;
 import javolution.xml.XMLObjectWriter;
-
 import org.mobicents.protocols.ss7.indicator.GlobalTitleIndicator;
 import org.mobicents.protocols.ss7.indicator.NatureOfAddress;
 import org.mobicents.protocols.ss7.indicator.NumberingPlan;
@@ -55,6 +45,15 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author amit bhayani
@@ -94,7 +93,7 @@ public class RuleTest {
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_DPC_AND_SSN, factory.createGlobalTitle( "917797706077/-",0, NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.INTERNATIONAL), 792,
                 8);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K/R", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K/R", 0, pattern, "K/R");
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("917797706077",0,
@@ -137,7 +136,7 @@ public class RuleTest {
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("123456789", 1), 0, 0);
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_DPC_AND_SSN, factory.createGlobalTitle("-"), 123, 8);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R", 0, pattern, "R");
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("123456789", 1), 0, 0);
@@ -164,7 +163,7 @@ public class RuleTest {
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("333/---/4", 1), 123, 0);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R/K/R", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R/K/R", 0, pattern, "R/K/R");
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("1234567", 1), 0, 0);
@@ -191,7 +190,7 @@ public class RuleTest {
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-/-"), 123, 8);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R/K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R/K", 0, pattern, "R/K");
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("4414257897897", 1), 0, 0);
@@ -217,7 +216,7 @@ public class RuleTest {
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_DPC_AND_SSN, factory.createGlobalTitle("-"), 123, 8);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0, pattern, "K");
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("4414257897897", 1), 0, 0);
@@ -244,7 +243,7 @@ public class RuleTest {
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-"), 6045, 6);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0, pattern, "K");
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("4414257897897",0,
@@ -277,7 +276,7 @@ public class RuleTest {
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-", 1), 123, 0);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0, pattern, "K");
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("1234567", 1), 0, 8);
@@ -303,7 +302,7 @@ public class RuleTest {
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-", 1), 123, 0);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0, pattern, "K");
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("55", 1), 0, 8);
@@ -320,7 +319,7 @@ public class RuleTest {
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-/-", 1), 123, 0);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K/K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K/K", 0, pattern, "K/K");
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("222", 1), 0, 8);
@@ -363,17 +362,17 @@ public class RuleTest {
         SccpMessage msgRemoteOrig = mesFact.createMessage(type, 101, 102, 0, buf, SccpProtocolVersion.ITU, 0);
 
         RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.LOCAL,
-                pattern, "K", 0);
+                pattern, "K", 0, pattern, "K");
         rule.setPrimaryAddressId(1);
         assertTrue(rule.matches(address, msgLocalOrig.getIsMtpOriginated(), 0));
         assertFalse(rule.matches(address, msgRemoteOrig.getIsMtpOriginated(), 0));
 
-        rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.REMOTE, pattern, "K", 0);
+        rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.REMOTE, pattern, "K", 0, pattern, "K");
         rule.setPrimaryAddressId(1);
         assertFalse(rule.matches(address, msgLocalOrig.getIsMtpOriginated(), 0));
         assertTrue(rule.matches(address, msgRemoteOrig.getIsMtpOriginated(), 0));
 
-        rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0);
+        rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0, pattern, "K");
         rule.setPrimaryAddressId(1);
         assertTrue(rule.matches(address, msgLocalOrig.getIsMtpOriginated(), 0));
         assertTrue(rule.matches(address, msgRemoteOrig.getIsMtpOriginated(), 0));
@@ -392,7 +391,7 @@ public class RuleTest {
         //TODO: XXX: this is not used at all ?
         SccpAddress newClgPartyAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("92300010321", 0, NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.INTERNATIONAL), 0, 146);
 
-        RuleImpl rule = new RuleImpl(RuleType.BROADCAST, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R", 0);
+        RuleImpl rule = new RuleImpl(RuleType.BROADCAST, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R", 0, pattern, "R");
         rule.setPrimaryAddressId(1);
         rule.setSecondaryAddressId(2);
         rule.setNewCallingPartyAddressId(3);
@@ -436,7 +435,7 @@ public class RuleTest {
 
         SccpAddress newClgPartyAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("92300010321", 0, NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.INTERNATIONAL), 0, 146);
 
-        RuleImpl rule = new RuleImpl(RuleType.DOMINANT, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K/K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.DOMINANT, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K/K", 0, pattern, "K/K");
         rule.setPrimaryAddressId(1);
         rule.setNewCallingPartyAddressId(3);
 
@@ -474,7 +473,7 @@ public class RuleTest {
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-/-"), 123, 8);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R/K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R/K", 0, pattern, "R/K");
         rule.setPrimaryAddressId(1);
 
         // Writes
@@ -501,7 +500,7 @@ public class RuleTest {
         assertEquals(aiOut.getSecondaryAddressId(), 0);
         assertNull(aiOut.getNewCallingPartyAddressId());
 
-        rule = new RuleImpl(RuleType.BROADCAST, LoadSharingAlgorithm.Bit2, OriginationType.LOCAL, pattern, "R/K", 0);
+        rule = new RuleImpl(RuleType.BROADCAST, LoadSharingAlgorithm.Bit2, OriginationType.LOCAL, pattern, "R/K", 0, pattern, "R/K");
         rule.setPrimaryAddressId(11);
         rule.setSecondaryAddressId(12);
         rule.setNewCallingPartyAddressId(13);
@@ -541,7 +540,7 @@ public class RuleTest {
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("333/---/4", 1), 123, 0);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R/K/R", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R/K/R", 0, pattern, "R/K/R");
         rule.setPrimaryAddressId(1);
         rule.setSecondaryAddressId(2);
 

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/translation/GT0001SccpStackImplTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/translation/GT0001SccpStackImplTest.java
@@ -22,8 +22,6 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.translation;
 
-import static org.testng.Assert.assertTrue;
-
 import org.mobicents.protocols.ss7.indicator.NatureOfAddress;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
 import org.mobicents.protocols.ss7.sccp.LoadSharingAlgorithm;
@@ -40,6 +38,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author amit bhayani
@@ -100,9 +100,9 @@ public class GT0001SccpStackImplTest extends SccpHarness {
         SccpAddress rule2SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle(
                 GT1_pattern_digits, NatureOfAddress.NATIONAL), 0, getSSN());
         super.router1.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/R/K", 22, -1, null, 0);
+                "K/R/K", 22, -1, null, 0, rule1SccpAddress, "K/R/K");
         super.router2.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "R/R/R", 33, -1, null, 0);
+                "R/R/R", 33, -1, null, 0, rule2SccpAddress, "R/R/R");
 
         // now create users, we need to override matchX methods, since our rules do kinky stuff with digits, plus
         User u1 = new User(sccpStack1.getSccpProvider(), a1, a2, getSSN()) {
@@ -165,9 +165,9 @@ public class GT0001SccpStackImplTest extends SccpHarness {
         SccpAddress rule2SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle(
                 GT1_pattern_digits, NatureOfAddress.NATIONAL), 0, getSSN());
         super.router1.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/R/K", 22, -1, null, 0);
+                "K/R/K", 22, -1, null, 0, rule1SccpAddress, "K/R/K");
         super.router2.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "R/K/R", 33, -1, null, 0);
+                "R/K/R", 33, -1, null, 0, rule2SccpAddress, "K/R/K");
 
         // add rules for incoming messages,
 
@@ -183,9 +183,9 @@ public class GT0001SccpStackImplTest extends SccpHarness {
         rule2SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle(
                 "02/?", NatureOfAddress.NATIONAL), 0, getSSN());
         super.router1.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/K/K", 44, -1, null, 0);
+                "K/K/K", 44, -1, null, 0, rule1SccpAddress, "K/R/K");
         super.router2.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "K/K", 66, -1, null, 0);
+                "K/K", 66, -1, null, 0, rule2SccpAddress, "R/R/R");
 
         // now create users, we need to override matchX methods, since our rules do kinky stuff with digits, plus
         User u1 = new User(sccpStack1.getSccpProvider(), a1, a2, getSSN()) {

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/translation/GT0010SccpStackImplTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/translation/GT0010SccpStackImplTest.java
@@ -22,8 +22,6 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.translation;
 
-import static org.testng.Assert.assertTrue;
-
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
 import org.mobicents.protocols.ss7.sccp.LoadSharingAlgorithm;
 import org.mobicents.protocols.ss7.sccp.OriginationType;
@@ -33,13 +31,14 @@ import org.mobicents.protocols.ss7.sccp.impl.User;
 import org.mobicents.protocols.ss7.sccp.message.SccpDataMessage;
 import org.mobicents.protocols.ss7.sccp.message.SccpMessage;
 import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle;
-import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle0010;
 import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author amit bhayani
@@ -98,9 +97,9 @@ public class GT0010SccpStackImplTest extends SccpHarness {
         SccpAddress rule2SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle(
                 GT1_pattern_digits, 0), 0, getSSN());
         super.router1.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/R/K", 22, -1, null, 0);
+                "K/R/K", 22, -1, null, 0, rule1SccpAddress, "K/R/K");
         super.router2.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "R/R/R", 33, -1, null, 0);
+                "R/R/R", 33, -1, null, 0, rule1SccpAddress, "R/R/R");
 
         // now create users, we need to override matchX methods, since our rules do kinky stuff with digits, plus
         User u1 = new User(sccpStack1.getSccpProvider(), a1, a2, getSSN()) {

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/translation/GT0011SccpStackImplTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/translation/GT0011SccpStackImplTest.java
@@ -22,8 +22,6 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.translation;
 
-import static org.testng.Assert.assertTrue;
-
 import org.mobicents.protocols.ss7.indicator.NumberingPlan;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
 import org.mobicents.protocols.ss7.sccp.LoadSharingAlgorithm;
@@ -40,6 +38,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author amit bhayani
@@ -108,9 +108,9 @@ public class GT0011SccpStackImplTest extends SccpHarness {
                 super.sccpProvider1.getParameterFactory().createGlobalTitle(GT1_pattern_digits, 0, NumberingPlan.ISDN_MOBILE,
                         null), 0, getSSN());
         super.router1.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/R/K", 22, -1, null, 0);
+                "K/R/K", 22, -1, null, 0, rule1SccpAddress, "K/R/K");
         super.router2.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "R/R/R", 33, -1, null, 0);
+                "R/R/R", 33, -1, null, 0, rule2SccpAddress, "R/R/R");
 
         // now create users, we need to override matchX methods, since our rules
         // do kinky stuff with digits, plus
@@ -188,9 +188,9 @@ public class GT0011SccpStackImplTest extends SccpHarness {
                 super.sccpProvider1.getParameterFactory().createGlobalTitle(GT1_pattern_digits, 0, NumberingPlan.ISDN_MOBILE,
                         null), 0, getSSN());
         super.router1.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/R/K", 22, -1, null, 0);
+                "K/R/K", 22, -1, null, 0, rule1SccpAddress, "K/R/K");
         super.router2.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "R/K/R", 33, -1, null, 0);
+                "R/K/R", 33, -1, null, 0, rule2SccpAddress, "R/K/R");
 
         // add rules for incoming messages,
 
@@ -210,9 +210,9 @@ public class GT0011SccpStackImplTest extends SccpHarness {
         rule2SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle("02/?", 0,
                 NumberingPlan.ISDN_TELEPHONY, null), 0, getSSN());
         super.router1.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/K/K", 44, -1, null, 0);
+                "K/K/K", 44, -1, null, 0, rule1SccpAddress, "K/K/K");
         super.router2.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "K/K", 66, -1, null, 0);
+                "K/K", 66, -1, null, 0, rule2SccpAddress, "K/K");
 
         // now create users, we need to override matchX methods, since our rules
         // do kinky stuff with digits, plus

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/translation/GT0100SccpStackImplTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/translation/GT0100SccpStackImplTest.java
@@ -22,8 +22,6 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.translation;
 
-import static org.testng.Assert.assertTrue;
-
 import org.mobicents.protocols.ss7.indicator.NatureOfAddress;
 import org.mobicents.protocols.ss7.indicator.NumberingPlan;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
@@ -41,6 +39,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author amit bhayani
@@ -101,9 +101,9 @@ public class GT0100SccpStackImplTest extends SccpHarness {
         SccpAddress rule2SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle(GT1_pattern_digits, 0,
                 NumberingPlan.ISDN_MOBILE, null, NatureOfAddress.NATIONAL), 0, getSSN());
         super.router1.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/R/K", 22, -1, null, 0);
+                "K/R/K", 22, -1, null, 0, rule1SccpAddress, "K/R/K");
         super.router2.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "R/R/R", 33, -1, null, 0);
+                "R/R/R", 33, -1, null, 0, rule2SccpAddress, "R/R/R");
 
         // now create users, we need to override matchX methods, since our rules
         // do kinky stuff with digits, plus
@@ -170,9 +170,9 @@ public class GT0100SccpStackImplTest extends SccpHarness {
         SccpAddress rule2SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle(GT1_pattern_digits, 0,
                 NumberingPlan.ISDN_MOBILE, null, NatureOfAddress.NATIONAL), 0, getSSN());
         super.router1.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/R/K", 22, -1, null, 0);
+                "K/R/K", 22, -1, null, 0, rule1SccpAddress, "K/R/K");
         super.router2.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "R/K/R", 33, -1, null, 0);
+                "R/K/R", 33, -1, null, 0, rule2SccpAddress, "R/K/R");
 
         // add rules for incoming messages,
 
@@ -188,9 +188,9 @@ public class GT0100SccpStackImplTest extends SccpHarness {
         rule2SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle("02/?", 0,
                 NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.NATIONAL), 0, getSSN());
         super.router1.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/K/K", 44, -1, null, 0);
+                "K/K/K", 44, -1, null, 0, rule1SccpAddress, "K/K/K");
         super.router2.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "K/K", 66, -1, null, 0);
+                "K/K", 66, -1, null, 0, rule2SccpAddress, "K/K");
 
         // now create users, we need to override matchX methods, since our rules
         // do kinky stuff with digits, plus


### PR DESCRIPTION
Fixes issu224 SCCP Routing based on callingGT
Added code for using callingparty as secondary match when available in the routing. Also fixed bugs in modify/addrule in sccpexecutor and routerimpl. jss7-management-console work is in progress.
CallingParty rule is used as secondary rule for sorting the rules when CalledRule is same for multiple rules. This allows better control on routing.
CallingParty rule only matches SSN and GT TYPE and GT digits. It doesn't have mask as address overridden is done via new calling-party address id.