### PR TITLE
Fixes Issue #224 SCCP Routing based on calling party

### DIFF
--- a/map/load/src/main/java/org/mobicents/protocols/ss7/map/load/Client.java
+++ b/map/load/src/main/java/org/mobicents/protocols/ss7/map/load/Client.java
@@ -221,9 +221,9 @@ public class Client extends TestHarness {
                 NatureOfAddress.INTERNATIONAL);
         SccpAddress pattern = new SccpAddressImpl(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, gt, 0, 0);
         this.sccpStack.getRouter().addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.REMOTE, pattern,
-                "K", 1, -1, null, 0);
+                "K", 1, -1, null, 0, null, "K");
         this.sccpStack.getRouter().addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern,
-                "K", 2, -1, null, 0);
+                "K", 2, -1, null, 0, null, "K");
     }
 
     private void initTCAP() throws Exception {

--- a/map/load/src/main/java/org/mobicents/protocols/ss7/map/load/Server.java
+++ b/map/load/src/main/java/org/mobicents/protocols/ss7/map/load/Server.java
@@ -211,9 +211,9 @@ public class Server extends TestHarness {
                 NatureOfAddress.INTERNATIONAL);
         SccpAddress pattern = new SccpAddressImpl(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, gt, 0, 0);
         this.sccpStack.getRouter().addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.REMOTE, pattern,
-                "K", 1, -1, null, 0);
+                "K", 1, -1, null, 0, null, "");
         this.sccpStack.getRouter().addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern,
-                "K", 2, -1, null, 0);
+                "K", 2, -1, null, 0, null, "");
     }
 
     private void initTCAP() throws Exception {

--- a/oam/common/sccp/src/main/java/org/mobicents/protocols/ss7/oam/common/sccp/SccpRouterJmx.java
+++ b/oam/common/sccp/src/main/java/org/mobicents/protocols/ss7/oam/common/sccp/SccpRouterJmx.java
@@ -21,8 +21,6 @@
  */
 package org.mobicents.protocols.ss7.oam.common.sccp;
 
-import java.util.Map;
-
 import org.mobicents.protocols.ss7.indicator.AddressIndicator;
 import org.mobicents.protocols.ss7.indicator.NatureOfAddress;
 import org.mobicents.protocols.ss7.indicator.NumberingPlan;
@@ -39,6 +37,8 @@ import org.mobicents.protocols.ss7.sccp.SccpProvider;
 import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle;
 import org.mobicents.protocols.ss7.sccp.parameter.ParameterFactory;
 import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
+
+import java.util.Map;
 
 /**
  * @author Amit Bhayani
@@ -105,9 +105,9 @@ public class SccpRouterJmx implements SccpRouterJmxMBean {
     @Override
     public void addRule(int id, RuleType ruleType, LoadSharingAlgorithm algo, OriginationType originationType,
             SccpAddress pattern, String mask, int pAddressId, int sAddressId, Integer newCallingPartyAddressAddressId,
-            int networkId) throws Exception {
+            int networkId, SccpAddress patternCallingAddress) throws Exception {
         this.wrappedRouter.addRule(id, ruleType, algo, originationType, pattern, mask, pAddressId, sAddressId,
-                newCallingPartyAddressAddressId, networkId);
+                newCallingPartyAddressAddressId, networkId, patternCallingAddress);
     }
 
     /*
@@ -242,9 +242,10 @@ public class SccpRouterJmx implements SccpRouterJmxMBean {
     @Override
     public void modifyRule(int id, RuleType ruleType, LoadSharingAlgorithm algo, OriginationType originationType,
             SccpAddress pattern, String mask, int pAddressId, int sAddressId, Integer newCallingPartyAddressAddressId,
-            int networkId) throws Exception {
+            int networkId, SccpAddress patternCallingAddress
+                           ) throws Exception {
         this.wrappedRouter.modifyRule(id, ruleType, algo, originationType, pattern, mask, pAddressId, sAddressId,
-                newCallingPartyAddressAddressId, networkId);
+                newCallingPartyAddressAddressId, networkId, patternCallingAddress);
     }
 
     /*
@@ -347,14 +348,17 @@ public class SccpRouterJmx implements SccpRouterJmxMBean {
 
     @Override
     public void addRule(int id, String ruleType, String algo, String originationType, int ai, int pc, int ssn, int tt, int np,
-            int nao, String digits, String mask, int pAddressId, int sAddressId, int newCallingPartyAddressAddressId, int networkId)
+            int nao, String digits, String mask, int pAddressId, int sAddressId, int newCallingPartyAddressAddressId, int networkId,
+                        int callingai, int callingpc, int callingssn, int callingtt, int callingnp,int callingnao, String callingdigits)
             throws Exception {
 
         SccpAddress patternAddress = this.createSccpAddress(ai, pc, ssn, tt, np, nao, digits);
 
+        SccpAddress patternAddressCalling = this.createSccpAddress(callingai, callingpc, callingssn, callingtt, callingnp, callingnao, callingdigits);
+
         this.wrappedRouter.addRule(id, RuleType.getInstance(ruleType), LoadSharingAlgorithm.getInstance(algo),
                 OriginationType.getInstance(originationType), patternAddress, mask, pAddressId, sAddressId,
-                newCallingPartyAddressAddressId == -1 ? null : newCallingPartyAddressAddressId, networkId);
+                newCallingPartyAddressAddressId == -1 ? null : newCallingPartyAddressAddressId, networkId, patternAddressCalling);
 
     }
 

--- a/oam/common/sccp/src/main/java/org/mobicents/protocols/ss7/oam/common/sccp/SccpRouterJmxMBean.java
+++ b/oam/common/sccp/src/main/java/org/mobicents/protocols/ss7/oam/common/sccp/SccpRouterJmxMBean.java
@@ -32,6 +32,7 @@ public interface SccpRouterJmxMBean extends Router {
     void addRoutingAddress(int id, int ai, int pc, int ssn, int tt, int np, int nao, String digits) throws Exception;
 
     void addRule(int id, String ruleType, String algo, String originationType, int ai, int pc, int ssn, int tt, int np, int nao, String digits, String mask,
-            int pAddressId, int sAddressId, int newCallingPartyAddressAddressId, int networkId) throws Exception;
+            int pAddressId, int sAddressId, int newCallingPartyAddressAddressId, int networkId, int callingai,
+                 int callingpc, int callingssn, int callingtt, int callingnp,int callingnao, String callingdigits) throws Exception;
 
 }

--- a/sccp/sccp-api/src/main/java/org/mobicents/protocols/ss7/sccp/Router.java
+++ b/sccp/sccp-api/src/main/java/org/mobicents/protocols/ss7/sccp/Router.java
@@ -21,9 +21,9 @@
  */
 package org.mobicents.protocols.ss7.sccp;
 
-import java.util.Map;
-
 import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
+
+import java.util.Map;
 
 /**
  *
@@ -71,10 +71,10 @@ public interface Router {
     Map<Integer, LongMessageRule> getLongMessageRules();
 
     void addRule(int id, RuleType ruleType, LoadSharingAlgorithm algo, OriginationType originationType, SccpAddress pattern, String mask, int pAddressId,
-            int sAddressId, Integer newCallingPartyAddressAddressId, int networkId) throws Exception;
+            int sAddressId, Integer newCallingPartyAddressAddressId, int networkId, SccpAddress patternCallingAddress) throws Exception;
 
     void modifyRule(int id, RuleType ruleType, LoadSharingAlgorithm algo, OriginationType originationType, SccpAddress pattern, String mask, int pAddressId,
-            int sAddressId, Integer newCallingPartyAddressAddressId, int networkId) throws Exception;
+            int sAddressId, Integer newCallingPartyAddressAddressId, int networkId, SccpAddress patternCallingAddress) throws Exception;
 
     Rule getRule(int id);
 

--- a/sccp/sccp-api/src/main/java/org/mobicents/protocols/ss7/sccp/Rule.java
+++ b/sccp/sccp-api/src/main/java/org/mobicents/protocols/ss7/sccp/Rule.java
@@ -50,8 +50,11 @@ public interface Rule {
 
     int getNetworkId();
 
-    boolean matches(SccpAddress address, boolean isMtpOriginated, int msgNetworkId);
+    SccpAddress getPatternCallingAddress();
+
+    boolean matches(SccpAddress address, SccpAddress callingAddress, boolean isMtpOriginated, int msgNetworkId);
 
     SccpAddress translate(SccpAddress address, SccpAddress ruleAddress);
+
 
 }

--- a/sccp/sccp-cli/src/main/resources/help/sccp_rule_create.txt
+++ b/sccp/sccp-cli/src/main/resources/help/sccp_rule_create.txt
@@ -7,7 +7,10 @@ SYNOPSIS
 	<ruleType> <primary-address-id> backup-addressid <backup-address-id> 
 	loadsharing-algo <loadsharing-algorithm> newcgparty-addressid 
 	<new-callingPartyAddress-id> origination-type <originationType>
-	stackname <stack-name> networkid <networkId>
+	stackname <stack-name> networkid <networkId> calling-ai <calling-address-indicator>
+	calling-pc <calling-point-code> calling-ssn <calling-subsystem-number> calling-tt <calling-translation-type>
+	calling-np <calling-numbering-plan> calling-nai <calling-nature-of-address-indicator>
+	calling-digits-pattern <calling-digits-pattern>
 
 DESCRIPTION
 	This command is used to create a new SCCP Routing Rule. You must ensure that 
@@ -321,16 +324,42 @@ PARAMETERS
 					If not passed, the first stack configured in ShellExecutor
 					will be used.	
 					
-   <networkId>     -  A digital parameter that specifies to which virtual SS7
-                    network this rule belongs. If this parameter 
-                    is skipped - networkId will be set to "0" by default.													
-	
+    <networkId>     -  A digital parameter that specifies to which virtual SS7
+                    network this rule belongs. If this parameter
+                    is skipped - networkId will be set to "0" by default.
+
+    <calling-address-indicator>     -  Address indicator for calling address matching. See above <address-indicator>
+
+    <calling-point-code>    -  Pointcode of calling sccp address. MTP Signaling Point Code. This is ignored if
+                    Bit '0' of address-indicator is not set.
+
+    <calling-subsystem-number>   -  This is ignored if Bit '1' of address-indicator is
+                    not set.
+
+    <calling-translation-type>   -  This is ignored if GT Indicator is 0000 or 0001.
+                    See <translation-type> above for more details.
+
+    <calling-numbering-plan>   -  A digital parameter that specifies to which virtual SS7
+                    network this rule belongs. If this parameter
+                    is skipped - networkId will be set to "0" by default.
+
+    <calling-nature-of-address-indicator>   -  The Nature of Address Indicator (NAI) field
+                    defines the address range for a specific numbering
+                    plan. This is only used if GT Indicator is 0100.
+
+     <calling-digits-pattern>   -  Specifies the string of digits divided into
+                    subsections using separator '/' depending on if
+                    the mask contains separator or not.
+                    See above <digits> for more information on pattern matching.
+
 EXAMPLES
 	sccp rule create 1 R 71 2 8 0 0 3 123456789 solitary 1
 
 	sccp rule create 2 R 71 2 8 0 0 3 123456789 dominant 1 backup-addressid 2
 
 	sccp rule create 2 R 71 2 8 0 0 3 123456789 loadshared 1 backup-addressid 2 loadsharing-algo bit4
+
+    sccp rule create 21 R 71 2 8 0 0 3 123456789 dominant 2 backup-addressid 1 loadsharing-algo bit3 newcgparty-addressid 1 origination-type remoteoriginated calling-ai 18 calling-pc 0 calling-ssn 0 calling-tt 0 calling-nai 0 calling-np 0 calling-digits-pattern 567*
 
 SEE ALSO
 	sccp sap create, sccp sap modify, sccp sap delete, sccp sap show, 

--- a/sccp/sccp-cli/src/main/resources/help/sccp_rule_modify.txt
+++ b/sccp/sccp-cli/src/main/resources/help/sccp_rule_modify.txt
@@ -294,14 +294,39 @@ PARAMETERS
    <networkId>     -  A digital parameter that specifies to which virtual SS7
                     network this rule belongs. If this parameter 
                     is skipped - networkId will be set to "0" by default.					
-					
+
+    <calling-address-indicator>     -  Address indicator for calling address matching. See above <address-indicator>
+
+    <calling-point-code>    -  Pointcode of calling sccp address. MTP Signaling Point Code. This is ignored if
+                    Bit '0' of address-indicator is not set.
+
+    <calling-subsystem-number>   -  This is ignored if Bit '1' of address-indicator is
+                    not set.
+
+    <calling-translation-type>   -  This is ignored if GT Indicator is 0000 or 0001.
+                    See <translation-type> above for more details.
+
+    <calling-numbering-plan>   -  A digital parameter that specifies to which virtual SS7
+                    network this rule belongs. If this parameter
+                    is skipped - networkId will be set to "0" by default.
+
+    <calling-nature-of-address-indicator>   -  The Nature of Address Indicator (NAI) field
+                    defines the address range for a specific numbering
+                    plan. This is only used if GT Indicator is 0100.
+
+     <calling-digits-pattern>   -  Specifies the string of digits divided into
+                    subsections using separator '/' depending on if
+                    the mask contains separator or not.
+                    See above <digits> for more information on pattern matching.
 EXAMPLES
 	sccp rule modify 1 R 71 2 8 0 0 3 123456789 solitary 1
 
 	sccp rule modify 2 R 71 2 8 0 0 3 123456789 dominant 1 backup-addressid 2
 
-	sccp rule modify 2 R 71 2 8 0 0 3 123456789 loadshared 1 backup-addressid 2 loadsharing-algo bit4												
-	
+	sccp rule modify 2 R 71 2 8 0 0 3 123456789 loadshared 1 backup-addressid 2 loadsharing-algo bit4
+
+	sccp rule create 21 R 71 2 8 0 0 3 123456789 dominant 2 backup-addressid 1 loadsharing-algo bit3 newcgparty-addressid 1 origination-type remoteoriginated calling-ai 18 calling-pc 0 calling-ssn 0 calling-tt 0 calling-nai 0 calling-np 0 calling-digits-pattern 567*
+
 SEE ALSO
 	sccp sap create, sccp sap modify, sccp sap delete, sccp sap show, 
 	sccp dest create, sccp dest modify, sccp dest delete, sccp dest show, 

--- a/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/SccpRoutingControl.java
+++ b/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/SccpRoutingControl.java
@@ -22,11 +22,7 @@
 
 package org.mobicents.protocols.ss7.sccp.impl;
 
-import java.io.IOException;
-import java.util.Map;
-
 import javolution.util.FastMap;
-
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
@@ -56,6 +52,9 @@ import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle;
 import org.mobicents.protocols.ss7.sccp.parameter.ReturnCause;
 import org.mobicents.protocols.ss7.sccp.parameter.ReturnCauseValue;
 import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
+
+import java.io.IOException;
+import java.util.Map;
 
 /**
  *
@@ -447,8 +446,9 @@ public class SccpRoutingControl {
         }
 
         SccpAddress calledPartyAddress = msg.getCalledPartyAddress();
+        SccpAddress callingPartyAddress = msg.getCallingPartyAddress();
 
-        Rule rule = this.sccpStackImpl.router.findRule(calledPartyAddress, msg.getIsMtpOriginated(), msg.getNetworkId());
+        Rule rule = this.sccpStackImpl.router.findRule(calledPartyAddress, callingPartyAddress, msg.getIsMtpOriginated(), msg.getNetworkId());
         if (rule == null) {
             if (logger.isEnabledFor(Level.WARN)) {
                 logger.warn(String.format(

--- a/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/SccpStackImpl.java
+++ b/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/SccpStackImpl.java
@@ -23,29 +23,12 @@
 package org.mobicents.protocols.ss7.sccp.impl;
 
 import io.netty.util.concurrent.DefaultThreadFactory;
-
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.util.Date;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.TimeUnit;
-
 import javolution.text.TextBuilder;
 import javolution.util.FastMap;
 import javolution.xml.XMLBinding;
 import javolution.xml.XMLObjectReader;
 import javolution.xml.XMLObjectWriter;
 import javolution.xml.stream.XMLStreamException;
-
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
@@ -84,10 +67,25 @@ import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle;
 import org.mobicents.protocols.ss7.sccp.parameter.ReturnCauseValue;
 import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
 
+import java.io.ByteArrayInputStream;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.Date;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
 import static org.mobicents.protocols.ss7.sccp.impl.message.MessageUtil.calculateLudtFieldsLengthWithoutData;
+import static org.mobicents.protocols.ss7.sccp.impl.message.MessageUtil.calculateUdtFieldsLengthWithoutData;
 import static org.mobicents.protocols.ss7.sccp.impl.message.MessageUtil.calculateXudtFieldsLengthWithoutData;
 import static org.mobicents.protocols.ss7.sccp.impl.message.MessageUtil.calculateXudtFieldsLengthWithoutData2;
-import static org.mobicents.protocols.ss7.sccp.impl.message.MessageUtil.calculateUdtFieldsLengthWithoutData;
 /**
  *
  * @author amit bhayani
@@ -813,7 +811,7 @@ public class SccpStackImpl implements SccpStack, Mtp3UserPartListener {
 
     private int getMaxUserDataLengthForGT(SccpAddress calledPartyAddress, SccpAddress callingPartyAddress, int msgNetworkId) {
 
-        Rule rule = this.router.findRule(calledPartyAddress, false, msgNetworkId);
+        Rule rule = this.router.findRule(calledPartyAddress, callingPartyAddress, false, msgNetworkId);
         if (rule == null) {
             return 0;
         }

--- a/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/oam/SccpExecutor.java
+++ b/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/oam/SccpExecutor.java
@@ -741,7 +741,7 @@ public class SccpExecutor implements ShellExecutor {
      * <nature-of-address-indicator> <digits> <ruleType> <primary-address-id> backup-addressid <backup-address-id>
      * loadsharing-algo <loadsharing-algorithm> newcgparty-addressid <new-callingPartyAddress-id> origination-type
      * <originationType> networkid <network-id> calling-ai <address-indicator> calling-pc <point-code> calling-ssn <calling-subsystem-number> calling-tt <calling-translation-type> calling-np <calling-numbering-plan>
-     * calling-nai <calling-nature-of-address-indicator> calling-digits <calling-digits> stackname <stack-name>
+     * calling-nai <calling-nature-of-address-indicator> calling-digits-pattern <calling-digits-pattern> stackname <stack-name>
      * </p>
      *
      * @param options
@@ -783,12 +783,12 @@ public class SccpExecutor implements ShellExecutor {
         int networkId = 0;
 
         // Calling Address fields with default values
-        int callingAI = 18;
+        int callingAI = -1;
         int callingPC = -1;
         int callingSSN = -1;
-        int callingTT = 0;
-        int callingNP = 1;
-        int callingNAI = 4;
+        int callingTT = -1;
+        int callingNP = -1;
+        int callingNAI = -1;
         String callingDigits = null; // having it default as * means everythign matches
 
         while (count < options.length) {
@@ -830,7 +830,7 @@ public class SccpExecutor implements ShellExecutor {
                 callingNP = Integer.parseInt( options[count++] );
             } else if (key.equals( "calling-nai" )) {
                 callingNAI = Integer.parseInt( options[count++] );
-            } else if (key.equals( "calling-digits" )) {
+            } else if (key.equals( "calling-digits-pattern" )) {
                 callingDigits = options[count++];
             } else {
                 return SccpOAMMessage.INVALID_COMMAND;
@@ -840,7 +840,7 @@ public class SccpExecutor implements ShellExecutor {
         this.setDefaultValue();
         SccpAddress pattern = this.createAddress(options, 5, true);
         SccpAddress callingPattern  = null;
-        if ( callingDigits != null ) {
+        if ( callingDigits != null && !callingDigits.isEmpty()) {
             callingPattern = this.createAddress( callingAI, callingPC, callingSSN, callingTT, callingNP, callingNAI, callingDigits, true );
         }
 
@@ -887,12 +887,12 @@ public class SccpExecutor implements ShellExecutor {
         int networkId = 0;
 
         // Calling Address fields with default values
-        int callingAI = 18;
+        int callingAI = -1;
         int callingPC = -1;
         int callingSSN = -1;
-        int callingTT = 0;
-        int callingNP = 1;
-        int callingNAI = 4;
+        int callingTT = -1;
+        int callingNP = -1;
+        int callingNAI = -1;
         String callingDigits = null; // having it default as null means no matching on callingPattern
         // TODO: Validate the AI/TT/NP/NAI in case callingDigits are provided
 
@@ -935,7 +935,7 @@ public class SccpExecutor implements ShellExecutor {
                 callingNP = Integer.parseInt( options[count++] );
             } else if (key.equals( "calling-nai" )) {
                 callingNAI = Integer.parseInt( options[count++] );
-            } else if (key.equals( "calling-digits" )) {
+            } else if (key.equals( "calling-digits-pattern" )) {
                 callingDigits = options[count++];
             }  else {
                 return SccpOAMMessage.INVALID_COMMAND;
@@ -945,7 +945,7 @@ public class SccpExecutor implements ShellExecutor {
         this.setDefaultValue();
         SccpAddress pattern = this.createAddress(options, 5, true);
         SccpAddress callingPattern  = null;
-        if ( callingDigits != null ) {
+        if ( callingDigits != null && !callingDigits.isEmpty()) {
             callingPattern = this.createAddress( callingAI, callingPC, callingSSN, callingTT, callingNP, callingNAI, callingDigits, true );
         }
 

--- a/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/oam/SccpExecutor.java
+++ b/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/oam/SccpExecutor.java
@@ -22,12 +22,7 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.oam;
 
-import java.util.Arrays;
-import java.util.Map;
-import java.util.Set;
-
 import javolution.util.FastMap;
-
 import org.apache.log4j.Logger;
 import org.mobicents.protocols.ss7.indicator.AddressIndicator;
 import org.mobicents.protocols.ss7.indicator.NatureOfAddress;
@@ -50,6 +45,10 @@ import org.mobicents.protocols.ss7.sccp.impl.parameter.SccpAddressImpl;
 import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle;
 import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
 import org.mobicents.ss7.management.console.ShellExecutor;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
 
 /**
  *
@@ -741,7 +740,8 @@ public class SccpExecutor implements ShellExecutor {
      * sccp rule create <id> <mask> <address-indicator> <point-code> <subsystem-number> <translation-type> <numbering-plan>
      * <nature-of-address-indicator> <digits> <ruleType> <primary-address-id> backup-addressid <backup-address-id>
      * loadsharing-algo <loadsharing-algorithm> newcgparty-addressid <new-callingPartyAddress-id> origination-type
-     * <originationType> stackname <stack-name>
+     * <originationType> networkid <network-id> calling-ai <address-indicator> calling-pc <point-code> calling-ssn <calling-subsystem-number> calling-tt <calling-translation-type> calling-np <calling-numbering-plan>
+     * calling-nai <calling-nature-of-address-indicator> calling-digits <calling-digits> stackname <stack-name>
      * </p>
      *
      * @param options
@@ -750,7 +750,7 @@ public class SccpExecutor implements ShellExecutor {
      */
     private String createRule(String[] options) throws Exception {
         // Minimum is 13
-        if (options.length < 14 || options.length > 24) {
+        if (options.length < 14 || options.length > 40) {
             return SccpOAMMessage.INVALID_COMMAND;
         }
         int ruleId = Integer.parseInt(options[3]);
@@ -782,6 +782,15 @@ public class SccpExecutor implements ShellExecutor {
         OriginationType originationType = OriginationType.ALL;
         int networkId = 0;
 
+        // Calling Address fields with default values
+        int callingAI = 18;
+        int callingPC = -1;
+        int callingSSN = -1;
+        int callingTT = 0;
+        int callingNP = 1;
+        int callingNAI = 4;
+        String callingDigits = null; // having it default as * means everythign matches
+
         while (count < options.length) {
             String key = options[count++];
             if (key == null) {
@@ -807,8 +816,22 @@ public class SccpExecutor implements ShellExecutor {
 
                 this.sccpStack = sccpStaclImpl;
             } else if (key.equals("networkid")) {
-                String networkIdS = options[count++];
-                networkId = Integer.parseInt(networkIdS);
+                String networkIdS = options[ count++ ];
+                networkId = Integer.parseInt( networkIdS );
+            } else if (key.equals( "calling-ai" )) {
+                callingAI = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-pc" )) {
+                callingPC = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-ssn" )) {
+                callingSSN = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-tt" )) {
+                callingTT = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-np" )) {
+                callingNP = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-nai" )) {
+                callingNAI = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-digits" )) {
+                callingDigits = options[count++];
             } else {
                 return SccpOAMMessage.INVALID_COMMAND;
             }
@@ -816,15 +839,20 @@ public class SccpExecutor implements ShellExecutor {
 
         this.setDefaultValue();
         SccpAddress pattern = this.createAddress(options, 5, true);
+        SccpAddress callingPattern  = null;
+        if ( callingDigits != null ) {
+            callingPattern = this.createAddress( callingAI, callingPC, callingSSN, callingTT, callingNP, callingNAI, callingDigits, true );
+        }
 
-        this.sccpStack.getRouter().addRule(ruleId, ruleType, algo, originationType, pattern, mask, pAddressId, sAddressId,
-                newcgpartyAddressId, networkId);
+        this.sccpStack.getRouter().addRule( ruleId, ruleType, algo, originationType, pattern, mask, pAddressId, sAddressId,
+                newcgpartyAddressId, networkId, callingPattern);
+
         return String.format(SccpOAMMessage.RULE_SUCCESSFULLY_ADDED, this.sccpStack.getName());
     }
 
     private String modifyRule(String[] options) throws Exception {
         // Minimum is 13
-        if (options.length < 14 || options.length > 24) {
+        if (options.length < 14 || options.length > 40) {
             return SccpOAMMessage.INVALID_COMMAND;
         }
         int ruleId = Integer.parseInt(options[3]);
@@ -858,6 +886,16 @@ public class SccpExecutor implements ShellExecutor {
         OriginationType originationType = OriginationType.ALL;
         int networkId = 0;
 
+        // Calling Address fields with default values
+        int callingAI = 18;
+        int callingPC = -1;
+        int callingSSN = -1;
+        int callingTT = 0;
+        int callingNP = 1;
+        int callingNAI = 4;
+        String callingDigits = null; // having it default as null means no matching on callingPattern
+        // TODO: Validate the AI/TT/NP/NAI in case callingDigits are provided
+
         while (count < options.length) {
             String key = options[count++];
             if (key == null) {
@@ -885,15 +923,34 @@ public class SccpExecutor implements ShellExecutor {
             } else if (key.equals("networkid")) {
                 String networkIdS = options[count++];
                 networkId = Integer.parseInt(networkIdS);
-            } else {
+            } else if (key.equals( "calling-ai" )) {
+                callingAI = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-pc" )) {
+                callingPC = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-ssn" )) {
+                callingSSN = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-tt" )) {
+                callingTT = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-np" )) {
+                callingNP = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-nai" )) {
+                callingNAI = Integer.parseInt( options[count++] );
+            } else if (key.equals( "calling-digits" )) {
+                callingDigits = options[count++];
+            }  else {
                 return SccpOAMMessage.INVALID_COMMAND;
             }
         }
 
         this.setDefaultValue();
         SccpAddress pattern = this.createAddress(options, 5, true);
+        SccpAddress callingPattern  = null;
+        if ( callingDigits != null ) {
+            callingPattern = this.createAddress( callingAI, callingPC, callingSSN, callingTT, callingNP, callingNAI, callingDigits, true );
+        }
+
         this.sccpStack.getRouter().modifyRule(ruleId, ruleType, algo, originationType, pattern, mask, pAddressId, sAddressId,
-                newcgpartyAddressId, networkId);
+                newcgpartyAddressId, networkId, callingPattern);
         return String.format(SccpOAMMessage.RULE_SUCCESSFULLY_MODIFIED, this.sccpStack.getName());
     }
 
@@ -1016,15 +1073,15 @@ public class SccpExecutor implements ShellExecutor {
 
         // sccp address create <id> <address-indicator> <point-code> <subsystemnumber> <translation-type> <numbering-plan>
         // <nature-of-address-indicator> <digits>
+        return createAddress(Integer.parseInt(options[index++]), Integer.parseInt(options[index++]), Integer.parseInt(options[index++]),
+                Integer.parseInt(options[index++]), Integer.parseInt(options[index++]), Integer.parseInt(options[index++]),
+                options[index++], isRule);
+    }
+
+    private SccpAddress createAddress(int ai, int pc, int ssn, int tt, int npValue, int naiValue, String digits, boolean isRule) throws Exception {
         SccpAddress sccpAddress = null;
 
-        int ai = Integer.parseInt(options[index++]);
-        int pc = 0;
-        int ssn = 0;
-
         AddressIndicator aiObj = new AddressIndicator((byte) ai, SccpProtocolVersion.ITU);
-        pc = Integer.parseInt(options[index++]);
-        ssn = Integer.parseInt(options[index++]);
 
 //        if (aiObj.isSSNPresent() && ssn == 0) {
 //            throw new Exception(
@@ -1040,11 +1097,8 @@ public class SccpExecutor implements ShellExecutor {
             throw new Exception(String.format("Point code parameter is mandatory and must be > 0"));
         }
 
-        int tt = Integer.parseInt(options[index++]);
-        NumberingPlan np = NumberingPlan.valueOf(Integer.parseInt(options[index++]));
-        NatureOfAddress nai = NatureOfAddress.valueOf(Integer.parseInt(options[index++]));
-
-        String digits = options[index++];
+        NumberingPlan np = NumberingPlan.valueOf(npValue);
+        NatureOfAddress nai = NatureOfAddress.valueOf(naiValue);
 
         GlobalTitle gt = null;
 

--- a/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleComparator.java
+++ b/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleComparator.java
@@ -21,9 +21,9 @@
  */
 package org.mobicents.protocols.ss7.sccp.impl.router;
 
-import java.util.Comparator;
-
 import org.mobicents.protocols.ss7.sccp.OriginationType;
+
+import java.util.Comparator;
 
 /**
  * <p>
@@ -70,6 +70,7 @@ public class RuleComparator implements Comparator<RuleImpl> {
      * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
      */
     public int compare(RuleImpl o1, RuleImpl o2) {
+
         String digits1 = o1.getPattern().getGlobalTitle().getDigits();
         String digits2 = o2.getPattern().getGlobalTitle().getDigits();
 
@@ -82,6 +83,30 @@ public class RuleComparator implements Comparator<RuleImpl> {
             return -1;
         if (o1.getOriginationType() == OriginationType.ALL && o2.getOriginationType() != OriginationType.ALL)
             return 1;
+
+        // Check if digits are exactly same. In that case we sort based on the callingDigits
+        if ( digits1.equals( digits2 )) {
+            // if rule1 has calling party and rule2 doesn't then we put rule1 first
+            if ( o1.getPatternCallingAddress() != null && o2.getPatternCallingAddress() == null ) {
+                return -1;
+            } else if ( o1.getPatternCallingAddress() == null && o2.getPatternCallingAddress() != null ) {
+                return 1;
+            } else if ( o1.getPatternCallingAddress() != null && o2.getPatternCallingAddress() != null ) {
+                // both have calling party addresses. lets compare these 2
+                digits1 = o1.getPatternCallingAddress().getGlobalTitle().getDigits();
+                digits2 = o2.getPatternCallingAddress().getGlobalTitle().getDigits();
+
+                // Normalize rule. Remove all separator
+                digits1 = digits1.replaceAll(SECTION_SEPARTOR, "");
+                digits2 = digits2.replaceAll(SECTION_SEPARTOR, "");
+
+                return compareDigits( digits1, digits2 );
+            }
+        }
+        return compareDigits( digits1, digits2 );
+    }
+
+    private int compareDigits( String digits1, String digits2 ) {
 
         // If any digit is just wildcard "*" return 1 indicating it should be
         // below the other
@@ -105,7 +130,6 @@ public class RuleComparator implements Comparator<RuleImpl> {
         }
 
         return 1;
-
     }
 
     /**

--- a/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleImpl.java
+++ b/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleImpl.java
@@ -22,12 +22,9 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.router;
 
-import java.io.Serializable;
-
 import javolution.text.CharArray;
 import javolution.xml.XMLFormat;
 import javolution.xml.stream.XMLStreamException;
-
 import org.apache.log4j.Logger;
 import org.mobicents.protocols.ss7.indicator.GlobalTitleIndicator;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
@@ -50,6 +47,8 @@ import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle0010;
 import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle0011;
 import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle0100;
 import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
+
+import java.io.Serializable;
 
 /**
  * @author amit bhayani
@@ -86,6 +85,7 @@ public class RuleImpl implements Rule, Serializable {
     private static final String SECONDARY_ADDRESS = "saddress";
     private static final String NEW_CALLING_PARTY_ADDRESS = "ncpaddress";
     private static final String MASK = "mask";
+    private static final String PATTERN_CALLING_ADDRESS = "patternCallingAddress";
 
     private static final String SEPARATOR = ";";
 
@@ -95,6 +95,7 @@ public class RuleImpl implements Rule, Serializable {
 
     /** Pattern used for selecting rule */
     private SccpAddress pattern;
+    private SccpAddress patternCallingAddress;
 
     private int ruleId;
 
@@ -108,6 +109,8 @@ public class RuleImpl implements Rule, Serializable {
 
     private String[] maskPattern = null;
 
+
+
     public static final int MIN_SIGNIFICANT_SSN = 1;
     public static final int MAX_SIGNIFICANT_SSN = 255;
 
@@ -119,14 +122,17 @@ public class RuleImpl implements Rule, Serializable {
      * Creates new routing rule.
      *
      */
-    public RuleImpl(RuleType ruleType, LoadSharingAlgorithm loadSharingAlgo, OriginationType originationType,
-            SccpAddress pattern, String mask, int networkId) {
+    public RuleImpl( RuleType ruleType, LoadSharingAlgorithm loadSharingAlgo, OriginationType originationType,
+                     SccpAddress pattern, String mask, int networkId, SccpAddress patternCallingAddress) {
         this.ruleType = ruleType;
         this.pattern = pattern;
         this.mask = mask;
         this.networkId = networkId;
         this.setLoadSharingAlgorithm(loadSharingAlgo);
         this.setOriginationType(originationType);
+
+        // Calling SCCP Address
+        this.patternCallingAddress = patternCallingAddress;
 
         configure();
     }
@@ -219,6 +225,10 @@ public class RuleImpl implements Rule, Serializable {
         this.networkId = networkId;
     }
 
+    public SccpAddress getPatternCallingAddress() {
+        return patternCallingAddress;
+    }
+
     /**
      * Translate specified address according to the rule.
      *
@@ -301,7 +311,7 @@ public class RuleImpl implements Rule, Serializable {
         }
     }
 
-    public boolean matches(SccpAddress address, boolean isMtpOriginated, int msgNetworkId) {
+    public boolean matches(SccpAddress address, SccpAddress callingAddress, boolean isMtpOriginated, int msgNetworkId) {
         if (logger.isTraceEnabled()) {
             logger.trace(String.format("Matching rule Id=%s Rule=[%s]", this.getRuleId(), this.toString()));
         }
@@ -345,9 +355,28 @@ public class RuleImpl implements Rule, Serializable {
             return false;
         }
 
+
+        if ( !matchGt( address, pattern ) ) {
+            return false; // Called GT didn't match. No point in going forward to match calling
+        }
+
+        if ( patternCallingAddress == null || callingAddress == null) {
+            // callingAddress or pattern is null then we consider it a match
+            return true;
+        }
+        // SSN matching for calling address just as for called address
+        if ( !isSsnMatch( callingAddress, patternCallingAddress ) ) {
+            return false;
+        }
+
+        // finally match on calling GT
+        return matchGt( callingAddress, patternCallingAddress );
+    }
+
+    private boolean matchGt( SccpAddress address, SccpAddress patternAddress ) {
         // Routing on GTT
         GlobalTitleIndicator gti = address.getAddressIndicator().getGlobalTitleIndicator();
-        GlobalTitle patternGT = pattern.getGlobalTitle();
+        GlobalTitle patternGT = patternAddress.getGlobalTitle();
         switch (gti) {
             case GLOBAL_TITLE_INCLUDES_NATURE_OF_ADDRESS_INDICATOR_ONLY:
                 GlobalTitle0001 gt = (GlobalTitle0001) address.getGlobalTitle();
@@ -456,7 +485,7 @@ public class RuleImpl implements Rule, Serializable {
                 }
 
                 // digits must match
-                if (!matchPattern(gt2.getDigits(), pattern.getGlobalTitle().getDigits())) {
+                if (!matchPattern(gt2.getDigits(), patternAddress.getGlobalTitle().getDigits())) {
                     if (logger.isDebugEnabled()) {
                         logger.debug(String.format("digits didn't match. Pattern digits=%s Address Digits=%s Return  False",
                                 patternGT.getDigits(), gt2.getDigits()));
@@ -486,7 +515,7 @@ public class RuleImpl implements Rule, Serializable {
                 }
 
                 // digits must match
-                if (!matchPattern(gt3.getDigits(), pattern.getGlobalTitle().getDigits())) {
+                if (!matchPattern(gt3.getDigits(), patternAddress.getGlobalTitle().getDigits())) {
                     if (logger.isDebugEnabled()) {
                         logger.debug(String.format("digits didn't match. Pattern digits=%s Address Digits=%s Return  False",
                                 patternGT.getDigits(), gt3.getDigits()));
@@ -642,6 +671,7 @@ public class RuleImpl implements Rule, Serializable {
             else
                 rule.newCallingPartyAddressId = null;
             rule.pattern = xml.get(PATTERN, SccpAddressImpl.class);
+            rule.patternCallingAddress = xml.get(PATTERN_CALLING_ADDRESS, SccpAddressImpl.class);
             rule.configure();
         }
 
@@ -656,6 +686,8 @@ public class RuleImpl implements Rule, Serializable {
             if (rule.newCallingPartyAddressId != null)
                 xml.setAttribute(NEW_CALLING_PARTY_ADDRESS, rule.newCallingPartyAddressId);
             xml.add((SccpAddressImpl)rule.pattern, PATTERN, SccpAddressImpl.class);
+            if ( rule.patternCallingAddress != null )
+                xml.add( ( SccpAddressImpl ) rule.patternCallingAddress, PATTERN_CALLING_ADDRESS, SccpAddressImpl.class );
         }
     };
 
@@ -723,6 +755,13 @@ public class RuleImpl implements Rule, Serializable {
         buff.append(this.networkId);
         buff.append(CLOSE_BRACKET);
 
+        if ( patternCallingAddress != null ) {
+            buff.append(SEPARATOR);
+            buff.append(PATTERN_CALLING_ADDRESS);
+            buff.append(OPEN_BRACKET);
+            buff.append( patternCallingAddress.toString() );
+            buff.append(CLOSE_BRACKET);
+        }
         return buff.toString();
     }
 }

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/congestion/CongestionLevelTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/congestion/CongestionLevelTest.java
@@ -22,15 +22,7 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.congestion;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Properties;
-
 import javolution.util.FastMap;
-
 import org.mobicents.protocols.ss7.indicator.NatureOfAddress;
 import org.mobicents.protocols.ss7.indicator.NumberingPlan;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
@@ -63,6 +55,13 @@ import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
 import org.mobicents.ss7.congestion.ExecutorCongestionMonitor;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Properties;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author Sergey Vetyutnev
@@ -107,7 +106,7 @@ public class CongestionLevelTest {
                 NatureOfAddress.INTERNATIONAL);
         SccpAddress sccpAddress1 = new SccpAddressImpl(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, gt1, 101, 8);
         router.addRoutingAddress(1, sccpAddress1);
-        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.ALL, pattern, "K", 1, -1, null, 1);
+        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.ALL, pattern, "K", 1, -1, null, 1, pattern);
 
         listenerProxy = new SccpListenerProxy();
         sccpStack.getSccpProvider().registerSccpListener(8, listenerProxy);

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/congestion/NetworkIdAffectedPCTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/congestion/NetworkIdAffectedPCTest.java
@@ -22,12 +22,7 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.congestion;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
 import javolution.util.FastMap;
-
 import org.mobicents.protocols.ss7.indicator.NatureOfAddress;
 import org.mobicents.protocols.ss7.indicator.NumberingPlan;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
@@ -47,6 +42,11 @@ import org.mobicents.protocols.ss7.sccp.impl.router.RouterImpl;
 import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle;
 import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author Sergey Vetyutnev
@@ -82,10 +82,10 @@ public class NetworkIdAffectedPCTest {
         router.addRoutingAddress(3, sccpAddress3);
         router.addRoutingAddress(4, sccpAddress4);
 
-        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.ALL, pattern, "K", 1, -1, null, 1);
-        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 2, -1, null, 2);
-        router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.REMOTE, pattern, "K", 3, -1, null, 3);
-        router.addRule(4, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.ALL, pattern, "K", 4, -1, null, 11);
+        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.ALL, pattern, "K", 1, -1, null, 1, pattern);
+        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 2, -1, null, 2, pattern);
+        router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.REMOTE, pattern, "K", 3, -1, null, 3, pattern);
+        router.addRule(4, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.ALL, pattern, "K", 4, -1, null, 11, pattern);
 
         map = router.getNetworkIdList(101);
         assertEquals(map.size(), 1);
@@ -124,7 +124,7 @@ public class NetworkIdAffectedPCTest {
         RemoteSignalingPointCodeImpl rspc2 = (RemoteSignalingPointCodeImpl) sccpStack.getSccpResource().getRemoteSpc(2);
 
         router.removeRule(2);
-        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 2, -1, null, 1);
+        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 2, -1, null, 1, pattern);
         map = router.getNetworkIdList(101);
         assertEquals(map.size(), 1);
         state = map.get(1);
@@ -134,7 +134,7 @@ public class NetworkIdAffectedPCTest {
 
         sccpAddress2 = new SccpAddressImpl(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, gt1, 101, 8);
         router.removeRule(2);
-        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, -1, null, 1);
+        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, -1, null, 1, pattern);
         map = router.getNetworkIdList(101);
         assertEquals(map.size(), 1);
         state = map.get(1);
@@ -148,8 +148,8 @@ public class NetworkIdAffectedPCTest {
         sccpAddress2 = new SccpAddressImpl(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, gt1, 102, 8);
         router.addRoutingAddress(1, sccpAddress1);
         router.addRoutingAddress(2, sccpAddress2);
-        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, -1, null, 1);
-        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 2, -1, null, 1);
+        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, -1, null, 1, pattern);
+        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 2, -1, null, 1, pattern);
         sccpStack.getSccpResource().addRemoteSpc(1, 101, 0, 0);
         sccpStack.getSccpResource().addRemoteSpc(2, 102, 0, 0);
         rspc1 = (RemoteSignalingPointCodeImpl) sccpStack.getSccpResource().getRemoteSpc(1);
@@ -196,7 +196,7 @@ public class NetworkIdAffectedPCTest {
         // Dominant
         router.removeRule(1);
         router.removeRule(2);
-        router.addRule(1, RuleType.DOMINANT, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, 2, null, 1);
+        router.addRule(1, RuleType.DOMINANT, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, 2, null, 1, pattern);
         SccpRspProxy.setCurrentRestrictionLevel(rspc1, 0);
         SccpRspProxy.setRemoteSpcProhibited(rspc1, false);
         SccpRspProxy.setCurrentRestrictionLevel(rspc2, 0);
@@ -248,7 +248,7 @@ public class NetworkIdAffectedPCTest {
 
         // Loadsharing
         router.removeRule(1);
-        router.addRule(1, RuleType.LOADSHARED, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, 2, null, 1);
+        router.addRule(1, RuleType.LOADSHARED, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, 2, null, 1, pattern);
         SccpRspProxy.setCurrentRestrictionLevel(rspc1, 0);
         SccpRspProxy.setRemoteSpcProhibited(rspc1, false);
         SccpRspProxy.setCurrentRestrictionLevel(rspc2, 0);
@@ -310,8 +310,8 @@ public class NetworkIdAffectedPCTest {
 
         // two affected networkIDs 
         router.removeRule(1);
-        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, -1, null, 1);
-        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 2, -1, null, 2);
+        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 1, -1, null, 1, pattern);
+        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.LOCAL, pattern, "K", 2, -1, null, 2, pattern);
         SccpRspProxy.setCurrentRestrictionLevel(rspc1, 4);
         SccpRspProxy.setRemoteSpcProhibited(rspc1, false);
         SccpRspProxy.setCurrentRestrictionLevel(rspc2, 2);

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/message/GetMaxUserDataLengthTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/message/GetMaxUserDataLengthTest.java
@@ -22,8 +22,6 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.message;
 
-import static org.testng.Assert.assertEquals;
-
 import org.mobicents.protocols.ss7.Util;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
 import org.mobicents.protocols.ss7.sccp.LoadSharingAlgorithm;
@@ -32,13 +30,13 @@ import org.mobicents.protocols.ss7.sccp.OriginationType;
 import org.mobicents.protocols.ss7.sccp.RuleType;
 import org.mobicents.protocols.ss7.sccp.impl.Mtp3UserPartImpl;
 import org.mobicents.protocols.ss7.sccp.impl.SccpStackImpl;
-import org.mobicents.protocols.ss7.sccp.impl.parameter.GlobalTitle0010Impl;
 import org.mobicents.protocols.ss7.sccp.impl.parameter.SccpAddressImpl;
-import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle;
 import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
 
 /**
  *
@@ -77,7 +75,7 @@ public class GetMaxUserDataLengthTest {
         stack.getRouter().addRoutingAddress(1, primaryAddress);
         SccpAddress pattern = new SccpAddressImpl(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, stack.getSccpProvider().getParameterFactory().createGlobalTitle("1122334455",0), 2, 18);
         stack.getRouter().addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 1,
-                -1, null, 0);
+                -1, null, 0, null);
 
         int len = stack.getSccpProvider().getMaxUserDataLength(a1, a2, 0);
         assertEquals(len, 248);

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/messageflow/CallingPartyAddressTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/messageflow/CallingPartyAddressTest.java
@@ -22,10 +22,6 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.messageflow;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-
 import org.mobicents.protocols.ss7.Util;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
 import org.mobicents.protocols.ss7.sccp.LoadSharingAlgorithm;
@@ -42,6 +38,10 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  *
@@ -128,7 +128,7 @@ public class CallingPartyAddressTest extends SccpHarness {
                 RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 sccpProvider1.getParameterFactory().createGlobalTitle("111111", 1), 0, 0);
         sccpStack1.getRouter().addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K",
-                1, -1, null, 0);
+                1, -1, null, 0, null);
 
         SccpAddress a3 = sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 sccpProvider1.getParameterFactory().createGlobalTitle("111111", 1), 0, 0);
@@ -145,7 +145,7 @@ public class CallingPartyAddressTest extends SccpHarness {
         // present newCallingPartyAddress
         sccpStack1.getRouter().removeRule(1);
         sccpStack1.getRouter().addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K",
-                1, -1, 2, 0);
+                1, -1, 2, 0, null);
 
         message = this.sccpProvider1.getMessageFactory().createDataMessageClass1(a3, a1, getDataSrc(), 0, 8, true, null, null);
         sccpProvider1.send(message);

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/messageflow/LoadSharingTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/messageflow/LoadSharingTest.java
@@ -22,8 +22,6 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.messageflow;
 
-import static org.testng.Assert.assertEquals;
-
 import org.mobicents.protocols.ss7.Util;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
 import org.mobicents.protocols.ss7.sccp.LoadSharingAlgorithm;
@@ -41,6 +39,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
 
 /**
  * 
@@ -147,7 +147,7 @@ public class LoadSharingTest extends SccpHarness {
                 RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 sccpProvider1.getParameterFactory().createGlobalTitle("222222", 1), 0, 0);
         sccpStack1.getRouter().addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K",
-                1, -1, null, 0);
+                1, -1, null, 0,null);
 
         // Primary and backup are available
         SccpAddress a3 = sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
@@ -204,7 +204,7 @@ public class LoadSharingTest extends SccpHarness {
         // ---- Dominant case
         sccpStack1.getRouter().removeRule(1);
         sccpStack1.getRouter().addRule(1, RuleType.DOMINANT, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K",
-                1, 3, null, 0);
+                1, 3, null, 0, null);
 
         // Primary and backup are available
         a3 = sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
@@ -260,10 +260,10 @@ public class LoadSharingTest extends SccpHarness {
         // ---- Loadshared case
         sccpStack1.getRouter().removeRule(1);
         sccpStack1.getRouter().addRule(1, RuleType.LOADSHARED, LoadSharingAlgorithm.Bit4, OriginationType.ALL, pattern, "K", 1,
-                3, null, 0);
+                3, null, 0, null);
         // rule which primaryAddress ssn==0 (getting ssn from origin CalledPartyAddress)
         sccpStack1.getRouter().addRule(2, RuleType.LOADSHARED, LoadSharingAlgorithm.Bit4, OriginationType.ALL, pattern2, "K",
-                2, 3, null, 0);
+                2, 3, null, 0, null);
 
         // Primary and backup are available
         // - class 1 (route by sls): sls = 0xEF: primary route (sls & 0x10 rule)
@@ -366,7 +366,7 @@ public class LoadSharingTest extends SccpHarness {
         sccpStack1.getRouter().removeRule(1);
         sccpStack1.getRouter().removeRule(2);
         sccpStack1.getRouter().addRule(1, RuleType.BROADCAST, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern,
-                "K", 1, 3, null, 0);
+                "K", 1, 3, null, 0, null);
 
         // Primary and backup are available
         a3 = sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/NetworkIdTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/NetworkIdTest.java
@@ -22,10 +22,6 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.router;
 
-import static org.testng.Assert.*;
-
-import java.io.IOException;
-
 import org.apache.log4j.Logger;
 import org.mobicents.protocols.ss7.indicator.NatureOfAddress;
 import org.mobicents.protocols.ss7.indicator.NumberingPlan;
@@ -66,6 +62,10 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+import static org.testng.Assert.assertEquals;
 
 /**
  * 
@@ -157,10 +157,11 @@ public class NetworkIdTest implements SccpListener {
         router.addRoutingAddress(4, primaryAddr2_L);
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
-        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.LOCAL, pattern, "K", 1, 1, null, 1);
-        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.LOCAL, pattern, "K", 2, 2, null, 2);
-        router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.REMOTE, pattern, "K", 3, 3, null, 1);
-        router.addRule(4, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.REMOTE, pattern, "K", 4, 4, null, 2);
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
+        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.LOCAL, pattern, "K", 1, 1, null, 1, patternDefaultCalling);
+        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.LOCAL, pattern, "K", 2, 2, null, 2, patternDefaultCalling);
+        router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.REMOTE, pattern, "K", 3, 3, null, 1, patternDefaultCalling);
+        router.addRule(4, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.REMOTE, pattern, "K", 4, 4, null, 2, patternDefaultCalling);
         // int id, RuleType ruleType, LoadSharingAlgorithm algo, OriginationType
         // originationType, SccpAddress pattern, String mask, int pAddressId,
         // int sAddressId, Integer newCallingPartyAddressAddressId, int networkId

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RouterTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RouterTest.java
@@ -357,6 +357,14 @@ public class RouterTest {
         router.addRule(8, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern8, "R/K", 8,
                 -1, null, 0, patternDefaultCalling);
 
+        // Rule 9 // with missing callingAddress
+
+        SccpAddress pattern9 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("999/2/*", 1), 0, 0);
+        SccpAddress primaryAddr9 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("111/-/-", 1), 123, 0);
+        router.addRoutingAddress(9, primaryAddr9);
+        router.addRule(9, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern9, "R/K/K",9,
+                -1, null, 0, null);
+
         // TEST find rule
 
         // Rule 6
@@ -369,6 +377,16 @@ public class RouterTest {
         assertEquals(RuleType.SOLITARY, rule.getRuleType());
         assertEquals(-1, rule.getSecondaryAddressId());
         assertEquals("K", rule.getMask());
+
+
+        // Rule 9
+        calledParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("999234", 1), 0, 0);
+        rule = router.findRule(calledParty, callingParty, false, 0);
+        assertEquals(LoadSharingAlgorithm.Undefined, rule.getLoadSharingAlgorithm());
+        assertEquals(pattern9, rule.getPattern());
+        assertEquals(RuleType.SOLITARY, rule.getRuleType());
+        assertEquals(-1, rule.getSecondaryAddressId());
+        assertEquals("R/K/K", rule.getMask());
 
         // Rule 7
         calledParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("1234567890", 1), 0, 0);
@@ -477,6 +495,28 @@ public class RouterTest {
                 null, 0, patternCalling4);
 
 
+        // Rule 5
+        SccpAddress pattern5 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("*", 1),0, 0);
+        SccpAddress primaryAddr5 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("333", 1), 123, 0);
+        router.addRoutingAddress(5, primaryAddr5);
+        SccpAddress patternCalling5 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("900/????/1", 1), 0, 0);
+
+        router.addRule(5, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern5, "R", 5, -1,
+                null, 0, patternCalling5);
+
+
+        // Rule 6
+        SccpAddress pattern6 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("800/????/9", 1),0, 0);
+        router.addRoutingAddress(6, primaryAddr1);
+
+        router.addRule(6, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern4, "K/K/R", 6, -1,
+                null, 0, null);
+
+
         // Rule Tests
 
         // Rule 3
@@ -489,6 +529,16 @@ public class RouterTest {
         assertEquals(-1, rule.getSecondaryAddressId());
         assertEquals("K/R/K", rule.getMask());
 
+        // Rule 6
+        callingParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "90012031", 1), 0, 0);
+        rule = router.findRule(calledParty, callingParty, false, 0);
+        assertEquals(LoadSharingAlgorithm.Undefined, rule.getLoadSharingAlgorithm());
+        assertEquals(pattern6, rule.getPattern());
+        assertEquals(RuleType.SOLITARY, rule.getRuleType());
+        assertEquals(-1, rule.getSecondaryAddressId());
+        assertEquals("K/K/R", rule.getMask());
+
+
         // Rule 1
         callingParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "9001203", 1), 0, 0);
         rule = router.findRule(calledParty, callingParty, false, 0);
@@ -497,6 +547,17 @@ public class RouterTest {
         assertEquals(RuleType.SOLITARY, rule.getRuleType());
         assertEquals(-1, rule.getSecondaryAddressId());
         assertEquals("R/K/R", rule.getMask());
+
+        // Rule 5
+        SccpAddress calledParty9 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "712345", 1), 0, 0);
+        callingParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "90012031", 1), 0, 0);
+        rule = router.findRule(calledParty9, callingParty, false, 0);
+        assertEquals(LoadSharingAlgorithm.Undefined, rule.getLoadSharingAlgorithm());
+        assertEquals(pattern5, rule.getPattern());
+        assertEquals(patternCalling5, rule.getPatternCallingAddress());
+        assertEquals(RuleType.SOLITARY, rule.getRuleType());
+        assertEquals(-1, rule.getSecondaryAddressId());
+        assertEquals("R", rule.getMask());
 
         // Rule 4
         callingParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "90012031", 1), 0, 0);

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RouterTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RouterTest.java
@@ -22,16 +22,7 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.router;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-
-import java.io.IOException;
-import java.util.Map;
-
 import javolution.util.FastMap;
-
 import org.mobicents.protocols.ss7.Util;
 import org.mobicents.protocols.ss7.indicator.GlobalTitleIndicator;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
@@ -64,6 +55,14 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author amit bhayani
@@ -128,11 +127,14 @@ public class RouterTest {
         assertEquals(router.getRoutingAddresses().size(), 1);
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("123456789",1),0, 0);
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*",1),0, 0);
 
-        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R", 2, 2, null, 0);
+        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R", 2,
+                2, null, 0, patternDefaultCalling);
         assertEquals(router.getRules().size(), 1);
 
-        router.addRule(2, RuleType.LOADSHARED, LoadSharingAlgorithm.Bit4, OriginationType.ALL, pattern, "K", 2, 2, null, 0);
+        router.addRule(2, RuleType.LOADSHARED, LoadSharingAlgorithm.Bit4, OriginationType.ALL, pattern, "K", 2,
+                2, null, 0, patternDefaultCalling);
         assertEquals(router.getRules().size(), 2);
 
         router.removeRule(2);
@@ -178,17 +180,18 @@ public class RouterTest {
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 factory.createGlobalTitle("*", 1), 0, 0);
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*",1),0, 0);
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_DPC_AND_SSN,
                 factory.createGlobalTitle("-"), 123, 146);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0, patternDefaultCalling);
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 factory.createGlobalTitle("4414257897897", 1), 0, 146);
 
-        assertTrue(rule.matches(address, false, 0));
+        assertTrue(rule.matches(address, address, false, 0));
 
         SccpAddress translatedAddress = rule.translate(address, primaryAddress);
 
@@ -208,16 +211,19 @@ public class RouterTest {
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 factory.createGlobalTitle("*", 1), 0, 146);
 
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("*", 1), 0, 0);
+
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_DPC_AND_SSN,
                 factory.createGlobalTitle("-"), 123, 146);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0, patternDefaultCalling);
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 factory.createGlobalTitle("4414257897897", 1), 0, 146);
 
-        assertTrue(rule.matches(address, false, 0));
+        assertTrue(rule.matches(address, address, false, 0));
 
         SccpAddress translatedAddress = rule.translate(address, primaryAddress);
 
@@ -236,8 +242,13 @@ public class RouterTest {
         router.addRoutingAddress(2, primaryAddr2);
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("123456789",1),0, 0);
+
+        String callingAddressDigits = "987654321";
+        SccpAddress patternCallingAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+               factory.createGlobalTitle(callingAddressDigits,1), 0, 0);
+
         router.addRule(1, RuleType.LOADSHARED, LoadSharingAlgorithm.Bit4, OriginationType.REMOTE, pattern, "K", 1, 2,
-                null, 6);
+                null, 6, patternCallingAddress );
 
         router.addLongMessageRule(1, 1, 2, LongMessageRuleType.XUDT_ENABLED);
         router.addMtp3ServiceAccessPoint(3, 1, 11, 2, 5);
@@ -266,6 +277,7 @@ public class RouterTest {
         assertEquals(sap.getMtp3Destinations().size(), 1);
         assertEquals(sap.getNetworkId(), 5);
         assertEquals(dst.getLastDpc(), 110);
+        assertTrue(rl.getPatternCallingAddress().getGlobalTitle().getDigits().equals( callingAddressDigits ));
 
         router1.stop();
     }
@@ -276,6 +288,9 @@ public class RouterTest {
     @Test(groups = { "router", "functional.order" })
     public void testOrdering() throws Exception {
 
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("*", 1), 0, 0);
+
         primaryAddr1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 factory.createGlobalTitle("333/---/4", 1), 123, 0);
         router.addRoutingAddress(1, primaryAddr1);
@@ -283,7 +298,7 @@ public class RouterTest {
         SccpAddress pattern1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 factory.createGlobalTitle("800/????/9", 1), 0, 0);
         router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern1, "R/K/R", 1, -1,
-                null, 0);
+                null, 0, patternDefaultCalling);
 
         // Rule 2
         SccpAddress pattern2 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
@@ -292,7 +307,8 @@ public class RouterTest {
                 factory.createGlobalTitle("-", 1), 123, 0);
         router.addRoutingAddress(2, primaryAddr2);
 
-        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern2, "K", 2, -1, null, 0);
+        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern2, "K", 2, -1,
+                null, 0, patternDefaultCalling);
 
         // Rule 3
         SccpAddress pattern3 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
@@ -301,7 +317,7 @@ public class RouterTest {
                 factory.createGlobalTitle("-/-/-/-", 1), 123, 0);
         router.addRoutingAddress(3, primaryAddr3);
         router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern3, "K/K/K/K", 3, -1,
-                null, 0);
+                null, 0, patternDefaultCalling);
 
         // Rule 4
         SccpAddress pattern4 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("80/??/0/???/9", 1),0, 0);
@@ -309,7 +325,7 @@ public class RouterTest {
                  0);
         router.addRoutingAddress(4, primaryAddr4);
         router.addRule(4, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern4, "R/K/R/K/R", 4, -1,
-                null, 0);
+                null, 0, patternDefaultCalling);
 
         // Rule 5
         SccpAddress pattern5 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,factory.createGlobalTitle("800/?????/9", 1), 0,  0);
@@ -317,32 +333,36 @@ public class RouterTest {
                 0);
         router.addRoutingAddress(5, primaryAddr5);
         router.addRule(5, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern5, "R/K/R", 5, -1,
-                null, 0);
+                null, 0, patternDefaultCalling);
 
         // Rule 6
         SccpAddress pattern6 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("123456",1), 0, 0);
         SccpAddress primaryAddr6 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-", 1),123, 0);
         router.addRoutingAddress(6, primaryAddr6);
-        router.addRule(6, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern6, "K", 6, -1, null, 0);
+        router.addRule(6, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern6, "K", 6,
+                -1, null, 0, patternDefaultCalling);
 
         // Rule 7
         SccpAddress pattern7 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("1234567890", 1), 0, 0);
         SccpAddress primaryAddr7 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-", 1), 123, 0);
         router.addRoutingAddress(7, primaryAddr7);
-        router.addRule(7, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern7, "K", 7, -1, null, 0);
+        router.addRule(7, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern7, "K", 7,
+                -1, null, 0, patternDefaultCalling);
 
         // Rule 8
 
         SccpAddress pattern8 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("999/*", 1), 0, 0);
         SccpAddress primaryAddr8 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("111/-", 1), 123, 0);
         router.addRoutingAddress(8, primaryAddr8);
-        router.addRule(8, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern8, "R/K", 8, -1, null, 0);
+        router.addRule(8, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern8, "R/K", 8,
+                -1, null, 0, patternDefaultCalling);
 
         // TEST find rule
 
         // Rule 6
         SccpAddress calledParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("123456", 1), 0, 0);
-        Rule rule = router.findRule(calledParty, false, 0);
+        SccpAddress callingParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("654321", 1), 0, 0); // does not matter as we have * as rule for calling
+        Rule rule = router.findRule(calledParty, callingParty, false, 0);
 
         assertEquals(LoadSharingAlgorithm.Undefined, rule.getLoadSharingAlgorithm());
         assertEquals(pattern6, rule.getPattern());
@@ -352,7 +372,7 @@ public class RouterTest {
 
         // Rule 7
         calledParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("1234567890", 1), 0, 0);
-        rule = router.findRule(calledParty, false, 0);
+        rule = router.findRule(calledParty, callingParty, false, 0);
         assertEquals(LoadSharingAlgorithm.Undefined, rule.getLoadSharingAlgorithm());
         assertEquals(pattern7, rule.getPattern());
         assertEquals(RuleType.SOLITARY, rule.getRuleType());
@@ -361,7 +381,7 @@ public class RouterTest {
 
         // Rule 1
         calledParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("80012039", 1), 0, 0);
-        rule = router.findRule(calledParty, false, 0);
+        rule = router.findRule(calledParty, callingParty, false, 0);
         assertEquals(LoadSharingAlgorithm.Undefined, rule.getLoadSharingAlgorithm());
         assertEquals(pattern1, rule.getPattern());
         assertEquals(RuleType.SOLITARY, rule.getRuleType());
@@ -370,7 +390,7 @@ public class RouterTest {
 
         // Rule 5
         calledParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("800120349", 1), 0, 0);
-        rule = router.findRule(calledParty, false, 0);
+        rule = router.findRule(calledParty, callingParty, false, 0);
         assertEquals(LoadSharingAlgorithm.Undefined, rule.getLoadSharingAlgorithm());
         assertEquals(pattern5, rule.getPattern());
         assertEquals(RuleType.SOLITARY, rule.getRuleType());
@@ -379,7 +399,7 @@ public class RouterTest {
 
         // Rule 4
         calledParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("801203459", 1), 0, 0);
-        rule = router.findRule(calledParty, false, 0);
+        rule = router.findRule(calledParty, callingParty, false, 0);
         assertEquals(LoadSharingAlgorithm.Undefined, rule.getLoadSharingAlgorithm());
         assertEquals(pattern4, rule.getPattern());
         assertEquals(RuleType.SOLITARY, rule.getRuleType());
@@ -388,7 +408,7 @@ public class RouterTest {
 
         // Rule 8
         calledParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("999123456", 1), 0, 0);
-        rule = router.findRule(calledParty, false, 0);
+        rule = router.findRule(calledParty, callingParty, false, 0);
         assertEquals(LoadSharingAlgorithm.Undefined, rule.getLoadSharingAlgorithm());
         assertEquals(pattern8, rule.getPattern());
         assertEquals(RuleType.SOLITARY, rule.getRuleType());
@@ -397,7 +417,7 @@ public class RouterTest {
 
         // Rule 3
         calledParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "919123456", 1), 0, 0);
-        rule = router.findRule(calledParty, false, 0);
+        rule = router.findRule(calledParty, callingParty, false, 0);
         assertEquals(LoadSharingAlgorithm.Undefined, rule.getLoadSharingAlgorithm());
         assertEquals(pattern3, rule.getPattern());
         assertEquals(RuleType.SOLITARY, rule.getRuleType());
@@ -407,29 +427,130 @@ public class RouterTest {
     }
 
     /**
+     * Test of Ordering by calling address pattern.
+     */
+    @Test(groups = { "router", "functional.order" })
+    public void testOrderingByCallingAddress() throws Exception {
+
+        // Rule 1
+        primaryAddr1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("333/---/4", 1), 123, 0);
+        router.addRoutingAddress(1, primaryAddr1);
+
+        SccpAddress patternCalling1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("900/????", 1), 0, 0);
+
+        SccpAddress pattern1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("800/????/9", 1), 0, 0);
+        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern1, "R/K/R", 1, -1,
+                null, 0, patternCalling1);
+
+
+        // Rule 2
+        SccpAddress pattern2 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("800/????/9", 1), 0, 0);
+        router.addRoutingAddress(2, primaryAddr1);
+        SccpAddress patternCalling2 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("*", 1), 0, 0);
+
+        router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern2, "K/K/K", 2, -1,
+                null, 0, patternCalling2);
+
+        // Rule 3
+        SccpAddress pattern3 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("800/????/9", 1), 0, 0);
+        router.addRoutingAddress(3, primaryAddr1);
+        SccpAddress patternCalling3 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("900/????/2", 1), 0, 0);
+
+        router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.ALL, pattern3, "K/R/K", 3, -1,
+                null, 0, patternCalling3);
+
+        // Rule 4
+        SccpAddress pattern4 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("800/????/9", 1),0, 0);
+        router.addRoutingAddress(4, primaryAddr1);
+        SccpAddress patternCalling4 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("900/????/1", 1), 0, 0);
+
+        router.addRule(4, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern4, "K/K/R", 4, -1,
+                null, 0, patternCalling4);
+
+
+        // Rule Tests
+
+        // Rule 3
+        SccpAddress calledParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "80012039", 1), 0, 0);
+        SccpAddress callingParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "90012032", 1), 0, 0);
+        Rule rule = router.findRule(calledParty, callingParty, false, 0);
+        assertEquals(LoadSharingAlgorithm.Bit0, rule.getLoadSharingAlgorithm());
+        assertEquals(pattern3, rule.getPattern());
+        assertEquals(RuleType.SOLITARY, rule.getRuleType());
+        assertEquals(-1, rule.getSecondaryAddressId());
+        assertEquals("K/R/K", rule.getMask());
+
+        // Rule 1
+        callingParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "9001203", 1), 0, 0);
+        rule = router.findRule(calledParty, callingParty, false, 0);
+        assertEquals(LoadSharingAlgorithm.Undefined, rule.getLoadSharingAlgorithm());
+        assertEquals(pattern4, rule.getPattern());
+        assertEquals(RuleType.SOLITARY, rule.getRuleType());
+        assertEquals(-1, rule.getSecondaryAddressId());
+        assertEquals("R/K/R", rule.getMask());
+
+        // Rule 4
+        callingParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "90012031", 1), 0, 0);
+        rule = router.findRule(calledParty, callingParty, false, 0);
+        assertEquals(LoadSharingAlgorithm.Undefined, rule.getLoadSharingAlgorithm());
+        assertEquals(pattern4, rule.getPattern());
+        assertEquals(RuleType.SOLITARY, rule.getRuleType());
+        assertEquals(-1, rule.getSecondaryAddressId());
+        assertEquals("K/K/R", rule.getMask());
+
+        // Rule 2
+        callingParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "90012037", 1), 0, 0);
+        rule = router.findRule(calledParty, callingParty, false, 0);
+        assertEquals(LoadSharingAlgorithm.Undefined, rule.getLoadSharingAlgorithm());
+        assertEquals(pattern2, rule.getPattern());
+        assertEquals(RuleType.SOLITARY, rule.getRuleType());
+        assertEquals(-1, rule.getSecondaryAddressId());
+        assertEquals("K/K/K", rule.getMask());
+
+    }
+    /**
+     * Test of Ordering.
+     */
+    @Test(groups = { "router", "functional.order" })
+    public void testRuleConfigReadWithoutCalling() throws Exception {
+    }
+    /**
      * Test of Ordering with OriginationType.
      */
     @Test(groups = { "router", "functional.order" })
     public void testOrderingWithOriginationType() throws Exception {
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                factory.createGlobalTitle("*", 1), 0, 0);
         // Rule 1
         primaryAddr1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("999", 1),123, 
                 0);
         router.addRoutingAddress(1, primaryAddr1);
 
         SccpAddress pattern1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
-        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern1, "K", 1, -1, null, 0);
+        router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern1, "K", 1,
+                -1, null, 0, patternDefaultCalling);
 
         // Rule 2
         router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.LOCAL, pattern1, "K", 1,
-                -1, null, 0);
+                -1, null, 0, patternDefaultCalling);
 
         // Rule 3
         SccpAddress pattern2 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("999", 1), 0, 0);
-        router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern2, "K", 1, -1, null, 0);
+        router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern2, "K", 1,
+                -1, null, 0, patternDefaultCalling);
 
         // Rule 4
         router.addRule(4, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.REMOTE, pattern2, "K",
-                1, -1, null, 0);
+                1, -1, null, 0, patternDefaultCalling);
 
         // TEST find rule
         boolean localOriginatedSign = false;
@@ -440,10 +561,10 @@ public class RouterTest {
         SccpAddress calledParty2 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 factory.createGlobalTitle("999", 1), 0, 0);
 
-        Rule rule1 = router.findRule(calledParty1, localOriginatedSign, 0);
-        Rule rule2 = router.findRule(calledParty1, remoteOriginatedSign, 0);
-        Rule rule3 = router.findRule(calledParty2, localOriginatedSign, 0);
-        Rule rule4 = router.findRule(calledParty2, remoteOriginatedSign, 0);
+        Rule rule1 = router.findRule(calledParty1, null, localOriginatedSign, 0);
+        Rule rule2 = router.findRule(calledParty1, null, remoteOriginatedSign, 0);
+        Rule rule3 = router.findRule(calledParty2, null, localOriginatedSign, 0);
+        Rule rule4 = router.findRule(calledParty2, null, remoteOriginatedSign, 0);
 
         assertTrue(rule1.getPattern().getGlobalTitle().getDigits().equals("*"));
         assertEquals(rule1.getOriginationType(), OriginationType.LOCAL);

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleComparatorTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleComparatorTest.java
@@ -21,10 +21,6 @@
  */
 package org.mobicents.protocols.ss7.sccp.impl.router;
 
-import static org.testng.Assert.assertEquals;
-
-import java.util.Arrays;
-
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
 import org.mobicents.protocols.ss7.sccp.LoadSharingAlgorithm;
 import org.mobicents.protocols.ss7.sccp.OriginationType;
@@ -37,6 +33,10 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.util.Arrays;
+
+import static org.testng.Assert.assertEquals;
 
 /**
  * @author amit bhayani
@@ -65,44 +65,45 @@ public class RuleComparatorTest {
     @Test(groups = { "comparator", "functional.sort" })
     public void testSorting() throws Exception {
 
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
         SccpAddress pattern1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("800/????/9", 1), 0, 0);
-        RuleImpl rule1 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern1, "R/K/R", 0);
+        RuleImpl rule1 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern1, "R/K/R", 0, patternDefaultCalling);
 
         RuleImpl rule1a = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.LOCAL,
-                pattern1, "R/K/R", 0);
+                pattern1, "R/K/R", 0, patternDefaultCalling);
 
         SccpAddress pattern2 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
-        RuleImpl rule2 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern2, "K", 0);
+        RuleImpl rule2 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern2, "K", 0, patternDefaultCalling);
 
         RuleImpl rule2a = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.LOCAL,
-                pattern2, "K", 0);
+                pattern2, "K", 0, patternDefaultCalling);
 
         SccpAddress pattern3 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("9/?/9/*", 1), 0, 0);
         RuleImpl rule3 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern3,
-                "K/K/K/K", 0);
+                "K/K/K/K", 0, patternDefaultCalling);
 
         RuleImpl rule3a = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.REMOTE,
-                pattern3, "K/K/K/K", 0);
+                pattern3, "K/K/K/K", 0, patternDefaultCalling);
 
         SccpAddress pattern4 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("80/??/0/???/9", 1), 0, 0);
         RuleImpl rule4 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern4,
-                "R/K/R/K/R", 0);
+                "R/K/R/K/R", 0, patternDefaultCalling);
 
         SccpAddress pattern5 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("800/?????/9", 1), 0, 0);
-        RuleImpl rule5 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern5, "R/K/R", 0);
+        RuleImpl rule5 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern5, "R/K/R", 0, patternDefaultCalling);
 
         SccpAddress pattern6 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("123456", 1), 0, 0);
-        RuleImpl rule6 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern6, "K", 0);
+        RuleImpl rule6 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern6, "K", 0, patternDefaultCalling);
 
         SccpAddress pattern7 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("1234567890", 1), 0, 0);
-        RuleImpl rule7 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern7, "R/K/R", 0);
+        RuleImpl rule7 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern7, "R/K/R", 0, patternDefaultCalling);
 
         SccpAddress pattern8 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("999/*", 1), 0, 0);
-        RuleImpl rule8 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern8, "R/K", 0);
+        RuleImpl rule8 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern8, "R/K", 0, patternDefaultCalling);
         
 
         SccpAddress pattern9 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("9999/*", 1), 0, 0);
-        RuleImpl rule9 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern9, "R/K", 0);
+        RuleImpl rule9 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern9, "R/K", 0, patternDefaultCalling);
 
         // This is unsorted
         RuleImpl[] rules = new RuleImpl[] { rule1, rule2, rule3, rule4, rule5, rule6, rule7, rule8, rule1a, rule2a, rule3a, rule9 };
@@ -123,5 +124,8 @@ public class RuleComparatorTest {
         assertEquals(rule8, rules[9]);
         assertEquals(rule3, rules[10]);
         assertEquals(rule2, rules[11]);
+
+
+        // TODO: write test for checking sorting on callingAddress
     }
 }

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleTest.java
@@ -22,19 +22,9 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.router;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-
 import javolution.xml.XMLBinding;
 import javolution.xml.XMLObjectReader;
 import javolution.xml.XMLObjectWriter;
-
 import org.mobicents.protocols.ss7.indicator.GlobalTitleIndicator;
 import org.mobicents.protocols.ss7.indicator.NatureOfAddress;
 import org.mobicents.protocols.ss7.indicator.NumberingPlan;
@@ -55,6 +45,15 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author amit bhayani
@@ -94,13 +93,13 @@ public class RuleTest {
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_DPC_AND_SSN, factory.createGlobalTitle( "917797706077/-",0, NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.INTERNATIONAL), 792,
                 8);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K/R", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K/R", 0, null);
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("917797706077",0,
                 NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.INTERNATIONAL), 0, 8);
 
-        assertTrue(rule.matches(address, false, 0));
+        assertTrue(rule.matches(address, null, false, 0));
 
         SccpAddress translatedAddress = rule.translate(address, primaryAddress);
 
@@ -116,7 +115,7 @@ public class RuleTest {
         address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("91779770607720",0,
                 NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.INTERNATIONAL), 0, 8);
 
-        assertTrue(rule.matches(address, false, 0));
+        assertTrue(rule.matches(address, null, false, 0));
 
         translatedAddress = rule.translate(address, primaryAddress);
 
@@ -137,12 +136,12 @@ public class RuleTest {
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("123456789", 1), 0, 0);
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_DPC_AND_SSN, factory.createGlobalTitle("-"), 123, 8);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R", 0, null);
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("123456789", 1), 0, 0);
 
-        assertTrue(rule.matches(address, false, 0));
+        assertTrue(rule.matches(address, null, false, 0));
 
         SccpAddress translatedAddress = rule.translate(address, primaryAddress);
 
@@ -161,15 +160,16 @@ public class RuleTest {
         // digits, then "7".
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("123/???/7", 1), 0, 0);
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("333/---/4", 1), 123, 0);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R/K/R", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R/K/R", 0, patternDefaultCalling);
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("1234567", 1), 0, 0);
 
-        assertTrue(rule.matches(address, false, 0));
+        assertTrue(rule.matches(address, null, false, 0));
 
         SccpAddress translatedAddress = rule.translate(address, primaryAddress);
 
@@ -188,15 +188,16 @@ public class RuleTest {
         // Keep any following digits in the Input. Add a PC(123) & SSN (8).
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("441425/*", 1), 0, 0);
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-/-"), 123, 8);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R/K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R/K", 0, patternDefaultCalling);
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("4414257897897", 1), 0, 0);
 
-        assertTrue(rule.matches(address, false, 0));
+        assertTrue(rule.matches(address, null, false, 0));
 
         SccpAddress translatedAddress = rule.translate(address, primaryAddress);
 
@@ -214,15 +215,16 @@ public class RuleTest {
         // Match any digits keep the digits in the and add a PC(123) & SSN (8).
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_DPC_AND_SSN, factory.createGlobalTitle("-"), 123, 8);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0, patternDefaultCalling);
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("4414257897897", 1), 0, 0);
 
-        assertTrue(rule.matches(address, false, 0));
+        assertTrue(rule.matches(address, null, false, 0));
 
         SccpAddress translatedAddress = rule.translate(address, primaryAddress);
 
@@ -241,16 +243,17 @@ public class RuleTest {
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "*",0,
                 NumberingPlan.valueOf(1),null, NatureOfAddress.valueOf(4)), 0, 6);
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-"), 6045, 6);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0, patternDefaultCalling);
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("4414257897897",0,
                 NumberingPlan.valueOf(1), null, NatureOfAddress.valueOf(4)), 0, 6);
 
-        assertTrue(rule.matches(address, false, 0));
+        assertTrue(rule.matches(address, null, false, 0));
 
         SccpAddress translatedAddress = rule.translate(address, primaryAddress);
 
@@ -274,15 +277,16 @@ public class RuleTest {
         // Match any GT Digits, keep the SSN from original address and add PC 123
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-", 1), 123, 0);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0, patternDefaultCalling);
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("1234567", 1), 0, 8);
 
-        assertTrue(rule.matches(address, false, 0));
+        assertTrue(rule.matches(address, null, false, 0));
 
         SccpAddress translatedAddress = rule.translate(address, primaryAddress);
 
@@ -300,16 +304,17 @@ public class RuleTest {
         // The case when address length is less then size
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("555", 1), 0, 0);
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-", 1), 123, 0);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0, patternDefaultCalling);
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("55", 1), 0, 8);
 
         // TODO: the exception is here
-        assertFalse(rule.matches(address, false, 0));
+        assertFalse(rule.matches(address, null, false, 0));
     }
 
     @Test(groups = { "router", "functional.translate" })
@@ -317,15 +322,16 @@ public class RuleTest {
         // Some bad pattern
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*/5555", 1), 0, 0);
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-/-", 1), 123, 0);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K/K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K/K", 0, patternDefaultCalling);
         rule.setPrimaryAddressId(1);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("222", 1), 0, 8);
 
-        assertTrue(rule.matches(address, false, 0));
+        assertTrue(rule.matches(address, null, false, 0));
 
         // TODO: the exception is here
         SccpAddress translatedAddress = rule.translate(address, primaryAddress);
@@ -344,6 +350,7 @@ public class RuleTest {
         // OriginationType checking
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("222", 1), 0, 8);
 
@@ -363,20 +370,20 @@ public class RuleTest {
         SccpMessage msgRemoteOrig = mesFact.createMessage(type, 101, 102, 0, buf, SccpProtocolVersion.ITU, 0);
 
         RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.LOCAL,
-                pattern, "K", 0);
+                pattern, "K", 0, null);
         rule.setPrimaryAddressId(1);
-        assertTrue(rule.matches(address, msgLocalOrig.getIsMtpOriginated(), 0));
-        assertFalse(rule.matches(address, msgRemoteOrig.getIsMtpOriginated(), 0));
+        assertTrue(rule.matches(address, address, msgLocalOrig.getIsMtpOriginated(), 0));
+        assertFalse(rule.matches(address, address, msgRemoteOrig.getIsMtpOriginated(), 0));
 
-        rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.REMOTE, pattern, "K", 0);
+        rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.REMOTE, pattern, "K", 0, patternDefaultCalling);
         rule.setPrimaryAddressId(1);
-        assertFalse(rule.matches(address, msgLocalOrig.getIsMtpOriginated(), 0));
-        assertTrue(rule.matches(address, msgRemoteOrig.getIsMtpOriginated(), 0));
+        assertFalse(rule.matches(address, address, msgLocalOrig.getIsMtpOriginated(), 0));
+        assertTrue(rule.matches(address, address, msgRemoteOrig.getIsMtpOriginated(), 0));
 
-        rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0);
+        rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K", 0, patternDefaultCalling);
         rule.setPrimaryAddressId(1);
-        assertTrue(rule.matches(address, msgLocalOrig.getIsMtpOriginated(), 0));
-        assertTrue(rule.matches(address, msgRemoteOrig.getIsMtpOriginated(), 0));
+        assertTrue(rule.matches(address, address, msgLocalOrig.getIsMtpOriginated(), 0));
+        assertTrue(rule.matches(address, address, msgRemoteOrig.getIsMtpOriginated(), 0));
     }
 
     @Test(groups = { "router", "functional.translate" })
@@ -385,6 +392,7 @@ public class RuleTest {
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("92300010020", 0,
                 NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.INTERNATIONAL), 0, 146);
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("92300010020", 0, NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.INTERNATIONAL), 7574, 146);
 
@@ -392,7 +400,7 @@ public class RuleTest {
         //TODO: XXX: this is not used at all ?
         SccpAddress newClgPartyAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("92300010321", 0, NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.INTERNATIONAL), 0, 146);
 
-        RuleImpl rule = new RuleImpl(RuleType.BROADCAST, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R", 0);
+        RuleImpl rule = new RuleImpl(RuleType.BROADCAST, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R", 0, patternDefaultCalling);
         rule.setPrimaryAddressId(1);
         rule.setSecondaryAddressId(2);
         rule.setNewCallingPartyAddressId(3);
@@ -400,7 +408,7 @@ public class RuleTest {
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("92300010020", 0,
                 NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.INTERNATIONAL), 0, 146);
 
-        assertTrue(rule.matches(address, true, 0));
+        assertTrue(rule.matches(address, null, true, 0));
 
         SccpAddress translatedAddress = rule.translate(address, primaryAddress);
 
@@ -431,19 +439,20 @@ public class RuleTest {
 
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("48??117/*", 0,
                 NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.INTERNATIONAL), 0, 146);
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("00/00", 0, NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.INTERNATIONAL), 7574, 146);
 
-        SccpAddress newClgPartyAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("92300010321", 0, NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.INTERNATIONAL), 0, 146);
-
-        RuleImpl rule = new RuleImpl(RuleType.DOMINANT, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K/K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.DOMINANT, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "K/K", 0, patternDefaultCalling);
         rule.setPrimaryAddressId(1);
         rule.setNewCallingPartyAddressId(3);
 
         SccpAddress address = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("48CC117735979971", 0,
                 NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.INTERNATIONAL), 0, 146);
 
-        assertTrue(rule.matches(address, true, 0));
+        SccpAddress address1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
+
+        assertTrue(rule.matches(address, address1, true, 0));
 
         SccpAddress translatedAddress = rule.translate(address, primaryAddress);
 
@@ -471,10 +480,11 @@ public class RuleTest {
     @Test(groups = { "router", "functional.encode" })
     public void testSerialization() throws Exception {
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("441425/*", 1), 0, 0);
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("5678/92", 1), 0, 0);
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-/-"), 123, 8);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R/K", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R/K", 0,patternDefaultCalling);
         rule.setPrimaryAddressId(1);
 
         // Writes
@@ -500,8 +510,9 @@ public class RuleTest {
         assertEquals(aiOut.getPrimaryAddressId(), 1);
         assertEquals(aiOut.getSecondaryAddressId(), 0);
         assertNull(aiOut.getNewCallingPartyAddressId());
+        assertTrue( aiOut.getPatternCallingAddress().getGlobalTitle().getDigits().equals( "5678/92") );
 
-        rule = new RuleImpl(RuleType.BROADCAST, LoadSharingAlgorithm.Bit2, OriginationType.LOCAL, pattern, "R/K", 0);
+        rule = new RuleImpl(RuleType.BROADCAST, LoadSharingAlgorithm.Bit2, OriginationType.LOCAL, pattern, "R/K", 0, patternDefaultCalling);
         rule.setPrimaryAddressId(11);
         rule.setSecondaryAddressId(12);
         rule.setNewCallingPartyAddressId(13);
@@ -529,6 +540,7 @@ public class RuleTest {
         assertEquals(aiOut.getPrimaryAddressId(), 11);
         assertEquals(aiOut.getSecondaryAddressId(), 12);
         assertEquals((int) aiOut.getNewCallingPartyAddressId(), 13);
+        assertTrue( aiOut.getPatternCallingAddress().getGlobalTitle().getDigits().equals( "5678/92") );
 
     }
 
@@ -538,10 +550,11 @@ public class RuleTest {
     @Test(groups = { "router", "functional.encode" })
     public void testToString() {
         SccpAddress pattern = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("123/???/7", 1), 0, 0);
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
 
         SccpAddress primaryAddress = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("333/---/4", 1), 123, 0);
 
-        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R/K/R", 0);
+        RuleImpl rule = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern, "R/K/R", 0, patternDefaultCalling);
         rule.setPrimaryAddressId(1);
         rule.setSecondaryAddressId(2);
 

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/translation/GT0001SccpStackImplTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/translation/GT0001SccpStackImplTest.java
@@ -22,8 +22,6 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.translation;
 
-import static org.testng.Assert.assertTrue;
-
 import org.mobicents.protocols.ss7.indicator.NatureOfAddress;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
 import org.mobicents.protocols.ss7.sccp.LoadSharingAlgorithm;
@@ -40,6 +38,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author amit bhayani
@@ -100,9 +100,9 @@ public class GT0001SccpStackImplTest extends SccpHarness {
         SccpAddress rule2SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle(
                 GT1_pattern_digits, NatureOfAddress.NATIONAL), 0, getSSN());
         super.router1.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/R/K", 22, -1, null, 0);
+                "K/R/K", 22, -1, null, 0, null);
         super.router2.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "R/R/R", 33, -1, null, 0);
+                "R/R/R", 33, -1, null, 0, null);
 
         // now create users, we need to override matchX methods, since our rules do kinky stuff with digits, plus
         User u1 = new User(sccpStack1.getSccpProvider(), a1, a2, getSSN()) {
@@ -165,9 +165,9 @@ public class GT0001SccpStackImplTest extends SccpHarness {
         SccpAddress rule2SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle(
                 GT1_pattern_digits, NatureOfAddress.NATIONAL), 0, getSSN());
         super.router1.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/R/K", 22, -1, null, 0);
+                "K/R/K", 22, -1, null, 0, null);
         super.router2.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "R/K/R", 33, -1, null, 0);
+                "R/K/R", 33, -1, null, 0, null);
 
         // add rules for incoming messages,
 
@@ -183,9 +183,9 @@ public class GT0001SccpStackImplTest extends SccpHarness {
         rule2SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle(
                 "02/?", NatureOfAddress.NATIONAL), 0, getSSN());
         super.router1.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/K/K", 44, -1, null, 0);
+                "K/K/K", 44, -1, null, 0, null);
         super.router2.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "K/K", 66, -1, null, 0);
+                "K/K", 66, -1, null, 0, null);
 
         // now create users, we need to override matchX methods, since our rules do kinky stuff with digits, plus
         User u1 = new User(sccpStack1.getSccpProvider(), a1, a2, getSSN()) {

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/translation/GT0010SccpStackImplTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/translation/GT0010SccpStackImplTest.java
@@ -22,8 +22,6 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.translation;
 
-import static org.testng.Assert.assertTrue;
-
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
 import org.mobicents.protocols.ss7.sccp.LoadSharingAlgorithm;
 import org.mobicents.protocols.ss7.sccp.OriginationType;
@@ -33,13 +31,14 @@ import org.mobicents.protocols.ss7.sccp.impl.User;
 import org.mobicents.protocols.ss7.sccp.message.SccpDataMessage;
 import org.mobicents.protocols.ss7.sccp.message.SccpMessage;
 import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle;
-import org.mobicents.protocols.ss7.sccp.parameter.GlobalTitle0010;
 import org.mobicents.protocols.ss7.sccp.parameter.SccpAddress;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author amit bhayani
@@ -97,10 +96,12 @@ public class GT0010SccpStackImplTest extends SccpHarness {
         SccpAddress rule1SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle(GT2_pattern_digits, 0), 0, getSSN());
         SccpAddress rule2SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle(
                 GT1_pattern_digits, 0), 0, getSSN());
+        SccpAddress patternDefaultCalling = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle("*", 0), 0, 0);
+
         super.router1.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/R/K", 22, -1, null, 0);
+                "K/R/K", 22, -1, null, 0, patternDefaultCalling);
         super.router2.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "R/R/R", 33, -1, null, 0);
+                "R/R/R", 33, -1, null, 0, patternDefaultCalling);
 
         // now create users, we need to override matchX methods, since our rules do kinky stuff with digits, plus
         User u1 = new User(sccpStack1.getSccpProvider(), a1, a2, getSSN()) {

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/translation/GT0011SccpStackImplTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/translation/GT0011SccpStackImplTest.java
@@ -22,8 +22,6 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.translation;
 
-import static org.testng.Assert.assertTrue;
-
 import org.mobicents.protocols.ss7.indicator.NumberingPlan;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
 import org.mobicents.protocols.ss7.sccp.LoadSharingAlgorithm;
@@ -40,6 +38,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author amit bhayani
@@ -107,10 +107,21 @@ public class GT0011SccpStackImplTest extends SccpHarness {
                 RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 super.sccpProvider1.getParameterFactory().createGlobalTitle(GT1_pattern_digits, 0, NumberingPlan.ISDN_MOBILE,
                         null), 0, getSSN());
+
+        SccpAddress patternCallingSccpAddress1 = super.sccpProvider1.getParameterFactory().createSccpAddress(
+                RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                super.sccpProvider1.getParameterFactory().createGlobalTitle("*", 0, NumberingPlan.ISDN_MOBILE,
+                        null), 0, getSSN());
+
         super.router1.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/R/K", 22, -1, null, 0);
+                "K/R/K", 22, -1, null, 0, patternCallingSccpAddress1);
+
+        SccpAddress patternCallingSccpAddress2 = super.sccpProvider1.getParameterFactory().createSccpAddress(
+                RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
+                super.sccpProvider1.getParameterFactory().createGlobalTitle("*", 0, NumberingPlan.ISDN_TELEPHONY,
+                        null), 0, getSSN());
         super.router2.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "R/R/R", 33, -1, null, 0);
+                "R/R/R", 33, -1, null, 0, patternCallingSccpAddress2);
 
         // now create users, we need to override matchX methods, since our rules
         // do kinky stuff with digits, plus
@@ -187,10 +198,14 @@ public class GT0011SccpStackImplTest extends SccpHarness {
                 RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 super.sccpProvider1.getParameterFactory().createGlobalTitle(GT1_pattern_digits, 0, NumberingPlan.ISDN_MOBILE,
                         null), 0, getSSN());
+        SccpAddress patternDefaultCalling = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle("*", 0,
+                NumberingPlan.ISDN_MOBILE, null), 0, 0);
         super.router1.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/R/K", 22, -1, null, 0);
+                "K/R/K", 22, -1, null, 0, patternDefaultCalling);
+        patternDefaultCalling = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle("*", 0,
+                NumberingPlan.ISDN_TELEPHONY, null), 0, 0);
         super.router2.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "R/K/R", 33, -1, null, 0);
+                "R/K/R", 33, -1, null, 0, patternDefaultCalling);
 
         // add rules for incoming messages,
 
@@ -209,10 +224,16 @@ public class GT0011SccpStackImplTest extends SccpHarness {
                 NumberingPlan.ISDN_MOBILE, null), 0, getSSN());
         rule2SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle("02/?", 0,
                 NumberingPlan.ISDN_TELEPHONY, null), 0, getSSN());
+
+        patternDefaultCalling = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle("*", 0,
+                NumberingPlan.ISDN_TELEPHONY, null), 0, 0);
         super.router1.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/K/K", 44, -1, null, 0);
+                "K/K/K", 44, -1, null, 0, patternDefaultCalling);
+
+        patternDefaultCalling = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle("*", 0,
+                NumberingPlan.ISDN_MOBILE, null), 0, 0);
         super.router2.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "K/K", 66, -1, null, 0);
+                "K/K", 66, -1, null, 0, patternDefaultCalling);
 
         // now create users, we need to override matchX methods, since our rules
         // do kinky stuff with digits, plus

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/translation/GT0100SccpStackImplTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/translation/GT0100SccpStackImplTest.java
@@ -22,8 +22,6 @@
 
 package org.mobicents.protocols.ss7.sccp.impl.translation;
 
-import static org.testng.Assert.assertTrue;
-
 import org.mobicents.protocols.ss7.indicator.NatureOfAddress;
 import org.mobicents.protocols.ss7.indicator.NumberingPlan;
 import org.mobicents.protocols.ss7.indicator.RoutingIndicator;
@@ -41,6 +39,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
 
 /**
  * @author amit bhayani
@@ -101,9 +101,9 @@ public class GT0100SccpStackImplTest extends SccpHarness {
         SccpAddress rule2SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle(GT1_pattern_digits, 0,
                 NumberingPlan.ISDN_MOBILE, null, NatureOfAddress.NATIONAL), 0, getSSN());
         super.router1.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/R/K", 22, -1, null, 0);
+                "K/R/K", 22, -1, null, 0, null);
         super.router2.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "R/R/R", 33, -1, null, 0);
+                "R/R/R", 33, -1, null, 0, null);
 
         // now create users, we need to override matchX methods, since our rules
         // do kinky stuff with digits, plus
@@ -169,10 +169,16 @@ public class GT0100SccpStackImplTest extends SccpHarness {
                 NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.NATIONAL), 0, getSSN());
         SccpAddress rule2SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle(GT1_pattern_digits, 0,
                 NumberingPlan.ISDN_MOBILE, null, NatureOfAddress.NATIONAL), 0, getSSN());
+
+        SccpAddress patternSccpCalling1 = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle("*", 0,
+                NumberingPlan.ISDN_MOBILE, null, NatureOfAddress.NATIONAL), 0, 0);
+        SccpAddress patternSccpCalling2 = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle("*", 0,
+                NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.NATIONAL), 0, 0);
+
         super.router1.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/R/K", 22, -1, null, 0);
+                "K/R/K", 22, -1, null, 0, patternSccpCalling1);
         super.router2.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "R/K/R", 33, -1, null, 0);
+                "R/K/R", 33, -1, null, 0, patternSccpCalling2);
 
         // add rules for incoming messages,
 
@@ -187,10 +193,18 @@ public class GT0100SccpStackImplTest extends SccpHarness {
                 NumberingPlan.ISDN_MOBILE, null, NatureOfAddress.NATIONAL), 0, getSSN());
         rule2SccpAddress = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle("02/?", 0,
                 NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.NATIONAL), 0, getSSN());
+
+        patternSccpCalling1 = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle("*", 0,
+                NumberingPlan.ISDN_TELEPHONY, null, NatureOfAddress.NATIONAL), 0, 0);
+
+        patternSccpCalling2 = super.sccpProvider1.getParameterFactory().createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, super.sccpProvider1.getParameterFactory().createGlobalTitle("*", 0,
+                NumberingPlan.ISDN_MOBILE, null, NatureOfAddress.NATIONAL), 0, 0);
+
+
         super.router1.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule1SccpAddress,
-                "K/K/K", 44, -1, null, 0);
+                "K/K/K", 44, -1, null, 0, patternSccpCalling1);
         super.router2.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, rule2SccpAddress,
-                "K/K", 66, -1, null, 0);
+                "K/K", 66, -1, null, 0, patternSccpCalling2);
 
         // now create users, we need to override matchX methods, since our rules
         // do kinky stuff with digits, plus

--- a/tools/simulator/core/src/main/java/org/mobicents/protocols/ss7/tools/simulator/level2/SccpMan.java
+++ b/tools/simulator/core/src/main/java/org/mobicents/protocols/ss7/tools/simulator/level2/SccpMan.java
@@ -367,11 +367,11 @@ public class SccpMan implements SccpManMBean, Stoppable {
                     0);
             String mask = "K";
             ((RouterImpl) this.router).addRule(1, RuleType.SOLITARY, null, OriginationType.LOCAL, pattern, mask, 1,
-                    -1, null, 0);
+                    -1, null, 0, pattern, mask);
             pattern = parameterFactory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, this.createGlobalTitle("*"), 0, 0);
             mask = "R";
             ((RouterImpl) this.router).addRule(2, RuleType.SOLITARY, null, OriginationType.REMOTE, pattern, mask, 2,
-                    -1, null, 0);
+                    -1, null, 0, pattern, mask);
         }
     }
 


### PR DESCRIPTION
Fixes issu224 SCCP Routing based on callingGT
Added code for using callingparty as secondary match when available in the routing. Also fixed bugs in modify/addrule in sccpexecutor and routerimpl. jss7-management-console work is in progress.
CallingParty rule is used as secondary rule for sorting the rules when CalledRule is same for multiple rules. This allows better control on routing.
CallingParty rule only matches SSN and GT TYPE and GT digits. It doesn't have mask as address overridden is done via new calling-party address id.

` sccp rule create <id> <mask> <address-indicator> <point-code> <subsystem-number> <translation-type> <numbering-plan><nature-of-address-indicator> <digits> <ruleType> <primary-address-id> backup-addressid <backup-address-id> loadsharing-algo <loadsharing-algorithm> newcgparty-addressid <new-callingPartyAddress-id> origination-type <originationType> networkid <network-id> calling-ai <address-indicator> calling-pc <point-code> calling-ssn <calling-subsystem-number> calling-tt <calling-translation-type> calling-np <calling-numbering-plan> calling-nai <calling-nature-of-address-indicator> calling-digits <calling-digits> stackname <stack-name>`