### PR TITLE
Fixes #249 RuleID based rulesorting instead of called/calling parameters

### DIFF
--- a/cap/cap-api/pom.xml
+++ b/cap/cap-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>cap-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.cap</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>cap-api</artifactId>

--- a/cap/cap-impl/pom.xml
+++ b/cap/cap-impl/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>cap-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.cap</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>cap-impl</artifactId>

--- a/cap/pom.xml
+++ b/cap/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 

--- a/congestion/pom.xml
+++ b/congestion/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<groupId>org.mobicents.protocols.ss7.congestion</groupId>

--- a/docs/commons/pom.xml
+++ b/docs/commons/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.docs</groupId>
 		<artifactId>restcomm-ss7-docs</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>restcomm-ss7-commons-sources</artifactId>

--- a/docs/installationguide/pom.xml
+++ b/docs/installationguide/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.docs</groupId>
 		<artifactId>restcomm-ss7-docs</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>restcomm-ss7-installguide</artifactId>

--- a/docs/installationguide/sources-asciidoc/pom.xml
+++ b/docs/installationguide/sources-asciidoc/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.docs.installguide</groupId>
 		<artifactId>restcomm-ss7-installguide</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>restcomm-ss7-installguide-sources-asciidoc</artifactId>

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7</groupId>
 		<artifactId>ss7-parent</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<groupId>org.mobicents.protocols.ss7.docs</groupId>

--- a/docs/userguide/pom.xml
+++ b/docs/userguide/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.docs</groupId>
 		<artifactId>restcomm-ss7-docs</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>restcomm-ss7-userguide</artifactId>

--- a/docs/userguide/sources-asciidoc/pom.xml
+++ b/docs/userguide/sources-asciidoc/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.docs.userguide</groupId>
 		<artifactId>restcomm-ss7-userguide</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>restcomm-ss7-userguide-sources-asciidoc</artifactId>

--- a/hardware/cli/pom.xml
+++ b/hardware/cli/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.hardware</groupId>
 		<artifactId>restcomm-hardware</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>linkset-cli</artifactId>

--- a/hardware/dahdi/java/pom.xml
+++ b/hardware/dahdi/java/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.hardware</groupId>
 		<artifactId>restcomm-dahdi-parent</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>restcomm-dahdi</artifactId>

--- a/hardware/dahdi/native/linux/pom.xml
+++ b/hardware/dahdi/native/linux/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.hardware</groupId>
 		<artifactId>restcomm-dahdi-native</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>librestcomm-dahdi-linux</artifactId>

--- a/hardware/dahdi/native/pom.xml
+++ b/hardware/dahdi/native/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.hardware</groupId>
 		<artifactId>restcomm-dahdi-parent</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>restcomm-dahdi-native</artifactId>

--- a/hardware/dahdi/pom.xml
+++ b/hardware/dahdi/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.hardware</groupId>
 		<artifactId>restcomm-hardware</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>restcomm-dahdi-parent</artifactId>

--- a/hardware/dialogic/java/pom.xml
+++ b/hardware/dialogic/java/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.hardware</groupId>
 		<artifactId>restcomm-dialogic-parent</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>restcomm-dialogic</artifactId>

--- a/hardware/dialogic/pom.xml
+++ b/hardware/dialogic/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.hardware</groupId>
 		<artifactId>restcomm-hardware</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>restcomm-dialogic-parent</artifactId>

--- a/hardware/linkset/pom.xml
+++ b/hardware/linkset/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.hardware</groupId>
 		<artifactId>restcomm-hardware</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>linkset</artifactId>

--- a/hardware/pom.xml
+++ b/hardware/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<groupId>org.mobicents.protocols.ss7.hardware</groupId>

--- a/inap/inap-api/pom.xml
+++ b/inap/inap-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>inap-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.inap</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>inap-api</artifactId>

--- a/inap/inap-impl/pom.xml
+++ b/inap/inap-impl/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>inap-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.inap</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>inap-impl</artifactId>

--- a/inap/pom.xml
+++ b/inap/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 

--- a/isup/isup-api/pom.xml
+++ b/isup/isup-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>isup-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.isup</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>isup-api</artifactId>

--- a/isup/isup-impl/pom.xml
+++ b/isup/isup-impl/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>isup-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.isup</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>isup-impl</artifactId>

--- a/isup/pom.xml
+++ b/isup/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 

--- a/m3ua/api/pom.xml
+++ b/m3ua/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>m3ua</artifactId>
 		<groupId>org.mobicents.protocols.ss7.m3ua</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>m3ua-api</artifactId>

--- a/m3ua/cli/m3ua/pom.xml
+++ b/m3ua/cli/m3ua/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>m3ua</artifactId>
 		<groupId>org.mobicents.protocols.ss7.m3ua</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/m3ua/cli/sctp/pom.xml
+++ b/m3ua/cli/sctp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>m3ua</artifactId>
 		<groupId>org.mobicents.protocols.ss7.m3ua</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 		<relativePath>../../pom.xml</relativePath>
 	</parent>
 

--- a/m3ua/impl/pom.xml
+++ b/m3ua/impl/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>m3ua</artifactId>
 		<groupId>org.mobicents.protocols.ss7.m3ua</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>m3ua-impl</artifactId>

--- a/m3ua/impl/src/test/java/org/mobicents/protocols/ss7/m3ua/impl/GatewayTest.java
+++ b/m3ua/impl/src/test/java/org/mobicents/protocols/ss7/m3ua/impl/GatewayTest.java
@@ -138,7 +138,7 @@ public class GatewayTest {
         System.out.println("Starting Client");
         client.start();
 
-        Thread.sleep(10000);
+        Thread.sleep(12000);
 
         // Both AS and ASP should be ACTIVE now
         assertEquals(AspState.getState(remAsp.getPeerFSM().getState().getName()), AspState.ACTIVE);

--- a/m3ua/pom.xml
+++ b/m3ua/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 

--- a/management/pom.xml
+++ b/management/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<groupId>org.mobicents.protocols.ss7.management</groupId>

--- a/management/shell-client/pom.xml
+++ b/management/shell-client/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.management</groupId>
 		<artifactId>management</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>shell-client</artifactId>

--- a/management/shell-server-api/pom.xml
+++ b/management/shell-server-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.management</groupId>
 		<artifactId>management</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>shell-server-api</artifactId>

--- a/management/shell-server-impl/pom.xml
+++ b/management/shell-server-impl/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.management</groupId>
 		<artifactId>management</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>shell-server-impl</artifactId>

--- a/management/shell-transport/pom.xml
+++ b/management/shell-transport/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.management</groupId>
 		<artifactId>management</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>shell-transport</artifactId>

--- a/map/load/pom.xml
+++ b/map/load/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>map-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.map</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>map-load</artifactId>

--- a/map/map-api/pom.xml
+++ b/map/map-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>map-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.map</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>map-api</artifactId>

--- a/map/map-impl/pom.xml
+++ b/map/map-impl/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>map-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.map</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>map-impl</artifactId>

--- a/map/pom.xml
+++ b/map/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 

--- a/mtp/mtp-api/pom.xml
+++ b/mtp/mtp-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.mtp</groupId>
 		<artifactId>mtp-parent</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>mtp-api</artifactId>

--- a/mtp/mtp-impl/pom.xml
+++ b/mtp/mtp-impl/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.mtp</groupId>
 		<artifactId>mtp-parent</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>mtp</artifactId>

--- a/mtp/pom.xml
+++ b/mtp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<groupId>org.mobicents.protocols.ss7.mtp</groupId>

--- a/oam/common/alarm/pom.xml
+++ b/oam/common/alarm/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.oam.common</groupId>
 		<artifactId>restcomm-ss7-oam-common</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>alarm</artifactId>

--- a/oam/common/jmx/pom.xml
+++ b/oam/common/jmx/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.oam.common</groupId>
 		<artifactId>restcomm-ss7-oam-common</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>jmx</artifactId>

--- a/oam/common/jmxss7/pom.xml
+++ b/oam/common/jmxss7/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.oam.common</groupId>
 		<artifactId>restcomm-ss7-oam-common</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>jmxss7</artifactId>

--- a/oam/common/linkset/pom.xml
+++ b/oam/common/linkset/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.oam.common</groupId>
 		<artifactId>restcomm-ss7-oam-common</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>linkset-oam</artifactId>

--- a/oam/common/m3ua/pom.xml
+++ b/oam/common/m3ua/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.oam.common</groupId>
 		<artifactId>restcomm-ss7-oam-common</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>m3ua-oam</artifactId>

--- a/oam/common/map/pom.xml
+++ b/oam/common/map/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.oam.common</groupId>
 		<artifactId>restcomm-ss7-oam-common</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>map-oam</artifactId>

--- a/oam/common/pom.xml
+++ b/oam/common/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.oam</groupId>
 		<artifactId>restcomm-ss7-oam</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<groupId>org.mobicents.protocols.ss7.oam.common</groupId>

--- a/oam/common/sccp/pom.xml
+++ b/oam/common/sccp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.oam.common</groupId>
 		<artifactId>restcomm-ss7-oam-common</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>sccp-oam</artifactId>

--- a/oam/common/sctp/pom.xml
+++ b/oam/common/sctp/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.oam.common</groupId>
 		<artifactId>restcomm-ss7-oam-common</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>sctp-oam</artifactId>

--- a/oam/common/statistics/api/pom.xml
+++ b/oam/common/statistics/api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.oam.common</groupId>
 		<artifactId>statistics-oam-parent</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>statistics-oam-api</artifactId>

--- a/oam/common/statistics/impl/pom.xml
+++ b/oam/common/statistics/impl/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.oam.common</groupId>
 		<artifactId>statistics-oam-parent</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>statistics-oam-impl</artifactId>

--- a/oam/common/statistics/pom.xml
+++ b/oam/common/statistics/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.oam.common</groupId>
 		<artifactId>restcomm-ss7-oam-common</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>statistics-oam-parent</artifactId>

--- a/oam/common/tcap/pom.xml
+++ b/oam/common/tcap/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.oam.common</groupId>
 		<artifactId>restcomm-ss7-oam-common</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>tcap-oam</artifactId>

--- a/oam/new-ui/pom.xml
+++ b/oam/new-ui/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.oam</groupId>
 		<artifactId>restcomm-ss7-oam</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>new-ui</artifactId>

--- a/oam/pom.xml
+++ b/oam/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7</groupId>
 		<artifactId>ss7-parent</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<groupId>org.mobicents.protocols.ss7.oam</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
 	<artifactId>ss7-parent</artifactId>
 	<groupId>org.mobicents.protocols.ss7</groupId>
-	<version>8.0.0-SNAPSHOT</version>
+	<version>8.0.107</version>
 
 	<packaging>pom</packaging>
 

--- a/sccp/pom.xml
+++ b/sccp/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 

--- a/sccp/sccp-api/pom.xml
+++ b/sccp/sccp-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>sccp-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.sccp</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>sccp-api</artifactId>

--- a/sccp/sccp-cli/pom.xml
+++ b/sccp/sccp-cli/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>sccp-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.sccp</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>sccp-cli</artifactId>

--- a/sccp/sccp-impl/pom.xml
+++ b/sccp/sccp-impl/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>sccp-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.sccp</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>sccp-impl</artifactId>

--- a/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RouterImpl.java
+++ b/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RouterImpl.java
@@ -207,7 +207,7 @@ public class RouterImpl implements Router {
 
     private String persistDir = null;
 
-    private final RuleComparator ruleComparator = new RuleComparator();
+    private RuleComparatorFactory ruleComparatorFactory = null;
     // rule list
     private RuleMap<Integer, Rule> rulesMap = new RuleMap<Integer, Rule>();
     private SccpAddressMap<Integer, SccpAddressImpl> routingAddresses = new SccpAddressMap<Integer, SccpAddressImpl>();
@@ -221,6 +221,7 @@ public class RouterImpl implements Router {
     public RouterImpl(String name, SccpStack sccpStack) {
         this.name = name;
         this.sccpStack = sccpStack;
+        this.ruleComparatorFactory = RuleComparatorFactory.getInstance("RuleComparatorFactory");
 
         binding.setAlias(RuleImpl.class, RULE);
         binding.setClassAttribute(CLASS_ATTRIBUTE);
@@ -246,6 +247,7 @@ public class RouterImpl implements Router {
     }
 
     public void start() {
+
         this.persistFile.clear();
 
         if (persistDir != null) {
@@ -447,7 +449,7 @@ public class RouterImpl implements Router {
             rulesArray[count++] = rule;
 
             // Sort
-            Arrays.sort(rulesArray, ruleComparator);
+            Arrays.sort(rulesArray, this.ruleComparatorFactory.getRuleComparator());
 
             RuleMap<Integer, Rule> newRule = new RuleMap<Integer, Rule>();
             for (int i = 0; i < rulesArray.length; i++) {
@@ -523,7 +525,7 @@ public class RouterImpl implements Router {
             rulesArray[count++] = rule;
 
             // Sort
-            Arrays.sort(rulesArray, ruleComparator);
+            Arrays.sort(rulesArray, this.ruleComparatorFactory.getRuleComparator());
 
             RuleMap<Integer, Rule> newRule = new RuleMap<Integer, Rule>();
             for (int i = 0; i < rulesArray.length; i++) {

--- a/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleByIdComparator.java
+++ b/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleByIdComparator.java
@@ -1,0 +1,14 @@
+package org.mobicents.protocols.ss7.sccp.impl.router;
+
+import java.util.Comparator;
+
+/**
+ * Created by faizan on 11/08/17.
+ */
+public class RuleByIdComparator  implements Comparator<RuleImpl> {
+
+    @Override
+    public int compare( RuleImpl o1, RuleImpl o2 ) {
+        return (o1.getRuleId() < o2.getRuleId() ? -1 : 1);
+    }
+}

--- a/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleComparator.java
+++ b/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleComparator.java
@@ -70,6 +70,16 @@ public class RuleComparator implements Comparator<RuleImpl> {
      * @see java.util.Comparator#compare(java.lang.Object, java.lang.Object)
      */
     public int compare(RuleImpl o1, RuleImpl o2) {
+        int res = compare1(o1, o2);
+        if (res < 0 ){
+            System.out.printf("%s -> %s\n", o1, o2);
+        } else {
+            System.out.printf("%s -> %s\n", o2, o1);
+        }
+        return res;
+    }
+
+    public int compare1(RuleImpl o1, RuleImpl o2) {
 
         String digits1 = o1.getPattern().getGlobalTitle().getDigits();
         String digits2 = o2.getPattern().getGlobalTitle().getDigits();
@@ -84,14 +94,23 @@ public class RuleComparator implements Comparator<RuleImpl> {
         if (o1.getOriginationType() == OriginationType.ALL && o2.getOriginationType() != OriginationType.ALL)
             return 1;
 
+        // if rule1 has calling party and rule2 doesn't then we put rule1 first
+//        if ( o1.getPatternCallingAddress() != null && o2.getPatternCallingAddress() == null ) {
+//            return -1;
+//        } else if ( o1.getPatternCallingAddress() == null && o2.getPatternCallingAddress() != null ) {
+//            return 1;
+//        }
+        // either both rules have callingPattern or none of them have it.
         // Check if digits are exactly same. In that case we sort based on the callingDigits
-        if ( digits1.equals( digits2 )) {
-            // if rule1 has calling party and rule2 doesn't then we put rule1 first
-            if ( o1.getPatternCallingAddress() != null && o2.getPatternCallingAddress() == null ) {
-                return -1;
-            } else if ( o1.getPatternCallingAddress() == null && o2.getPatternCallingAddress() != null ) {
-                return 1;
-            } else if ( o1.getPatternCallingAddress() != null && o2.getPatternCallingAddress() != null ) {
+        if ( digits1.equals( digits2 ) && (o1.getPatternCallingAddress() != null || o2.getPatternCallingAddress() != null )) {
+//            if ( o1.getPatternCallingAddress() != null && o2.getPatternCallingAddress() != null ) {
+                if ( o1.getPatternCallingAddress() != null &&
+                        o2.getPatternCallingAddress() == null  ) {
+                    return -1;
+                } else if ( o1.getPatternCallingAddress() == null &&
+                        o2.getPatternCallingAddress() != null ) {
+                    return 1;
+                }
                 // both have calling party addresses. lets compare these 2
                 digits1 = o1.getPatternCallingAddress().getGlobalTitle().getDigits();
                 digits2 = o2.getPatternCallingAddress().getGlobalTitle().getDigits();
@@ -101,7 +120,7 @@ public class RuleComparator implements Comparator<RuleImpl> {
                 digits2 = digits2.replaceAll(SECTION_SEPARTOR, "");
 
                 return compareDigits( digits1, digits2 );
-            }
+//            }
         }
         return compareDigits( digits1, digits2 );
     }
@@ -129,7 +148,8 @@ public class RuleComparator implements Comparator<RuleImpl> {
             return -1;
         }
 
-        return 1;
+        return digits1.compareTo( digits2 );
+//        return 1;
     }
 
     /**

--- a/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleComparatorFactory.java
+++ b/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleComparatorFactory.java
@@ -1,0 +1,40 @@
+package org.mobicents.protocols.ss7.sccp.impl.router;
+
+import java.util.Comparator;
+
+/**
+ * Created by faizan on 11/08/17.
+ */
+public class RuleComparatorFactory {
+
+    private final String name;
+
+    private static RuleComparatorFactory instance = null;
+    private Comparator<RuleImpl> ruleComparator = new RuleComparator(); // by default we have this one
+
+    public RuleComparatorFactory( String name ) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return this.name;
+    }
+    public static RuleComparatorFactory getInstance( String name) {
+        if ( instance == null ) {
+            instance = new RuleComparatorFactory( name);
+        }
+        return instance;
+    }
+
+    public static RuleComparatorFactory getInstance() {
+        return instance;
+    }
+
+    public void setRuleComparator(Comparator<RuleImpl> comparator) {
+        this.ruleComparator = comparator;
+    }
+
+    public Comparator<RuleImpl> getRuleComparator() {
+        return this.ruleComparator;
+    }
+}

--- a/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleImpl.java
+++ b/sccp/sccp-impl/src/main/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleImpl.java
@@ -360,13 +360,19 @@ public class RuleImpl implements Rule, Serializable {
             return false; // Called GT didn't match. No point in going forward to match calling
         }
 
-        if ( patternCallingAddress == null || callingAddress == null) {
+        if ( patternCallingAddress == null || callingAddress == null ) {
             // callingAddress or pattern is null then we consider it a match
             return true;
         }
         // SSN matching for calling address just as for called address
         if ( !isSsnMatch( callingAddress, patternCallingAddress ) ) {
             return false;
+        }
+
+        if ( patternCallingAddress.getGlobalTitle() == null ||
+                callingAddress.getGlobalTitle() == null ) {
+            // callingAddress or pattern have no GT then no point in matching them
+            return true;
         }
 
         // finally match on calling GT

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RouterTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RouterTest.java
@@ -298,7 +298,7 @@ public class RouterTest {
         SccpAddress pattern1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 factory.createGlobalTitle("800/????/9", 1), 0, 0);
         router.addRule(1, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern1, "R/K/R", 1, -1,
-                null, 0, patternDefaultCalling);
+                null, 0, null);
 
         // Rule 2
         SccpAddress pattern2 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
@@ -308,7 +308,7 @@ public class RouterTest {
         router.addRoutingAddress(2, primaryAddr2);
 
         router.addRule(2, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern2, "K", 2, -1,
-                null, 0, patternDefaultCalling);
+                null, 0, null);
 
         // Rule 3
         SccpAddress pattern3 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
@@ -317,7 +317,7 @@ public class RouterTest {
                 factory.createGlobalTitle("-/-/-/-", 1), 123, 0);
         router.addRoutingAddress(3, primaryAddr3);
         router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern3, "K/K/K/K", 3, -1,
-                null, 0, patternDefaultCalling);
+                null, 0, null);
 
         // Rule 4
         SccpAddress pattern4 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("80/??/0/???/9", 1),0, 0);
@@ -325,7 +325,7 @@ public class RouterTest {
                  0);
         router.addRoutingAddress(4, primaryAddr4);
         router.addRule(4, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern4, "R/K/R/K/R", 4, -1,
-                null, 0, patternDefaultCalling);
+                null, 0, null);
 
         // Rule 5
         SccpAddress pattern5 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,factory.createGlobalTitle("800/?????/9", 1), 0,  0);
@@ -333,21 +333,21 @@ public class RouterTest {
                 0);
         router.addRoutingAddress(5, primaryAddr5);
         router.addRule(5, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern5, "R/K/R", 5, -1,
-                null, 0, patternDefaultCalling);
+                null, 0, null);
 
         // Rule 6
         SccpAddress pattern6 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("123456",1), 0, 0);
         SccpAddress primaryAddr6 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-", 1),123, 0);
         router.addRoutingAddress(6, primaryAddr6);
         router.addRule(6, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern6, "K", 6,
-                -1, null, 0, patternDefaultCalling);
+                -1, null, 0, null);
 
         // Rule 7
         SccpAddress pattern7 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("1234567890", 1), 0, 0);
         SccpAddress primaryAddr7 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("-", 1), 123, 0);
         router.addRoutingAddress(7, primaryAddr7);
         router.addRule(7, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern7, "K", 7,
-                -1, null, 0, patternDefaultCalling);
+                -1, null, 0, null);
 
         // Rule 8
 
@@ -355,7 +355,7 @@ public class RouterTest {
         SccpAddress primaryAddr8 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("111/-", 1), 123, 0);
         router.addRoutingAddress(8, primaryAddr8);
         router.addRule(8, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern8, "R/K", 8,
-                -1, null, 0, patternDefaultCalling);
+                -1, null, 0, null);
 
         // Rule 9 // with missing callingAddress
 
@@ -456,7 +456,7 @@ public class RouterTest {
         router.addRoutingAddress(1, primaryAddr1);
 
         SccpAddress patternCalling1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
-                factory.createGlobalTitle("900/????", 1), 0, 0);
+                factory.createGlobalTitle("90012345", 1), 0, 0);
 
         SccpAddress pattern1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
                 factory.createGlobalTitle("800/????/9", 1), 0, 0);
@@ -479,7 +479,7 @@ public class RouterTest {
                 factory.createGlobalTitle("800/????/9", 1), 0, 0);
         router.addRoutingAddress(3, primaryAddr1);
         SccpAddress patternCalling3 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
-                factory.createGlobalTitle("900/????/2", 1), 0, 0);
+                factory.createGlobalTitle("900/?????/2", 1), 0, 0);
 
         router.addRule(3, RuleType.SOLITARY, LoadSharingAlgorithm.Bit0, OriginationType.ALL, pattern3, "K/R/K", 3, -1,
                 null, 0, patternCalling3);
@@ -489,7 +489,7 @@ public class RouterTest {
                 factory.createGlobalTitle("800/????/9", 1),0, 0);
         router.addRoutingAddress(4, primaryAddr1);
         SccpAddress patternCalling4 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
-                factory.createGlobalTitle("900/????/1", 1), 0, 0);
+                factory.createGlobalTitle("700/????/1", 1), 0, 0);
 
         router.addRule(4, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern4, "K/K/R", 4, -1,
                 null, 0, patternCalling4);
@@ -510,10 +510,10 @@ public class RouterTest {
 
         // Rule 6
         SccpAddress pattern6 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE,
-                factory.createGlobalTitle("800/????/9", 1),0, 0);
+                factory.createGlobalTitle("700/????/9", 1),0, 0);
         router.addRoutingAddress(6, primaryAddr1);
 
-        router.addRule(6, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern4, "K/K/R", 6, -1,
+        router.addRule(6, RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern6, "K/K/R", 6, -1,
                 null, 0, null);
 
 
@@ -521,7 +521,7 @@ public class RouterTest {
 
         // Rule 3
         SccpAddress calledParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "80012039", 1), 0, 0);
-        SccpAddress callingParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "90012032", 1), 0, 0);
+        SccpAddress callingParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "900120342", 1), 0, 0);
         Rule rule = router.findRule(calledParty, callingParty, false, 0);
         assertEquals(LoadSharingAlgorithm.Bit0, rule.getLoadSharingAlgorithm());
         assertEquals(pattern3, rule.getPattern());
@@ -530,8 +530,9 @@ public class RouterTest {
         assertEquals("K/R/K", rule.getMask());
 
         // Rule 6
+        SccpAddress calledParty1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "70012039", 1), 0, 0);
         callingParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "90012031", 1), 0, 0);
-        rule = router.findRule(calledParty, callingParty, false, 0);
+        rule = router.findRule(calledParty1, callingParty, false, 0);
         assertEquals(LoadSharingAlgorithm.Undefined, rule.getLoadSharingAlgorithm());
         assertEquals(pattern6, rule.getPattern());
         assertEquals(RuleType.SOLITARY, rule.getRuleType());
@@ -540,7 +541,7 @@ public class RouterTest {
 
 
         // Rule 1
-        callingParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "9001203", 1), 0, 0);
+        callingParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "90012345", 1), 0, 0);
         rule = router.findRule(calledParty, callingParty, false, 0);
         assertEquals(LoadSharingAlgorithm.Undefined, rule.getLoadSharingAlgorithm());
         assertEquals(pattern4, rule.getPattern());
@@ -560,7 +561,7 @@ public class RouterTest {
         assertEquals("R", rule.getMask());
 
         // Rule 4
-        callingParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "90012031", 1), 0, 0);
+        callingParty = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle( "70012031", 1), 0, 0);
         rule = router.findRule(calledParty, callingParty, false, 0);
         assertEquals(LoadSharingAlgorithm.Undefined, rule.getLoadSharingAlgorithm());
         assertEquals(pattern4, rule.getPattern());

--- a/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleComparatorTest.java
+++ b/sccp/sccp-impl/src/test/java/org/mobicents/protocols/ss7/sccp/impl/router/RuleComparatorTest.java
@@ -126,6 +126,83 @@ public class RuleComparatorTest {
         assertEquals(rule2, rules[11]);
 
 
-        // TODO: write test for checking sorting on callingAddress
+        // test for checking sorting on callingAddress
+        SccpAddress patternCallingDigits1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("8888", 1), 0, 0);
+        pattern1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("1234", 1), 0, 0);
+        rule1 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern1, "K", 0, null);
+
+        pattern2 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("1234", 1), 0, 0);
+        rule2 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern2, "K", 0, patternCallingDigits1);
+
+        pattern3 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("5678*", 1), 0, 0);
+        rule3 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern3, "K", 0, null);
+
+        pattern4 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("12234", 1), 0, 0);
+        rule4 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern4, "K", 0, null);
+
+        SccpAddress patternCallingDigits5 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("88889", 1), 0, 0);
+        pattern5 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("12234", 1), 0, 0);
+        rule5 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern5, "K", 0, patternCallingDigits5);
+
+        rules = new RuleImpl[] { rule1, rule5, rule2, rule3, rule4};
+        Arrays.sort( rules, ruleComparator );
+        assertEquals( rule5, rules[0]);
+        assertEquals( rule4, rules[1]);
+        assertEquals( rule2, rules[2]);
+        assertEquals( rule1, rules[3]);
+        assertEquals( rule3, rules[4]);
+    }
+
+    @Test(groups = { "comparator", "functional.sort" })
+    public void testSortingById() throws Exception {
+
+        SccpAddress patternDefaultCalling = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
+        SccpAddress pattern1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("800/????/9", 1), 0, 0);
+        RuleImpl rule1 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern1, "R/K/R", 0, patternDefaultCalling);
+        rule1.setRuleId( 5 );
+
+        SccpAddress pattern2 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("*", 1), 0, 0);
+        RuleImpl rule2 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern2, "K", 0, patternDefaultCalling);
+
+        rule2.setRuleId( 3 );
+
+
+        SccpAddress pattern3 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("9/?/9/*", 1), 0, 0);
+        RuleImpl rule3 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern3,
+                "K/K/K/K", 0, patternDefaultCalling);
+        rule3.setRuleId( 4 );
+
+        SccpAddress pattern4 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("80/??/0/???/9", 1), 0, 0);
+        RuleImpl rule4 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern4,
+                "R/K/R/K/R", 0, patternDefaultCalling);
+        rule4.setRuleId( 1 );
+
+        SccpAddress patternCallingDigits1 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("8888", 1), 0, 0);
+        SccpAddress pattern5 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("1234", 1), 0, 0);
+        RuleImpl rule5 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern5, "K", 0, null);
+        rule5.setRuleId( 2 );
+
+        SccpAddress pattern6 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("1234", 1), 0, 0);
+        RuleImpl rule6 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern6, "K", 0, patternCallingDigits1);
+        rule6.setRuleId( 7 );
+
+        SccpAddress pattern7 = factory.createSccpAddress(RoutingIndicator.ROUTING_BASED_ON_GLOBAL_TITLE, factory.createGlobalTitle("5678*", 1), 0, 0);
+        RuleImpl rule7 = new RuleImpl(RuleType.SOLITARY, LoadSharingAlgorithm.Undefined, OriginationType.ALL, pattern7, "K", 0, null);
+        rule7.setRuleId( 6 );
+
+        // This is unsorted
+        RuleImpl[] rules = new RuleImpl[] { rule1, rule2, rule3, rule4, rule5, rule6, rule7};
+
+        RuleByIdComparator ruleByIdComparator = new RuleByIdComparator();
+        // Sort
+        Arrays.sort(rules, ruleByIdComparator);
+
+        assertEquals(rule1, rules[4]);
+        assertEquals(rule2, rules[2]);
+        assertEquals(rule3, rules[3]);
+        assertEquals(rule4, rules[0]);
+        assertEquals(rule5, rules[1]);
+        assertEquals(rule6, rules[6]);
+        assertEquals(rule7, rules[5]);
     }
 }

--- a/scheduler/pom.xml
+++ b/scheduler/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<groupId>org.mobicents.protocols.ss7.scheduler</groupId>

--- a/service/jboss/pom.xml
+++ b/service/jboss/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<artifactId>restcomm-service-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>restcomm-ss7</artifactId>

--- a/service/jboss/src/main/config/jboss-beans.xml
+++ b/service/jboss/src/main/config/jboss-beans.xml
@@ -492,5 +492,16 @@
 		</constructor>
 	</bean>
 -->
+	<!--<bean name="RuleByIdComparator" class="org.mobicents.protocols.ss7.sccp.impl.router.RuleByIdComparator"/>-->
+	<bean name="RuleComparator" class="org.mobicents.protocols.ss7.sccp.impl.router.RuleComparator"/>
+	<bean name="RuleComparatorFactory" class="org.mobicents.protocols.ss7.sccp.impl.router.RuleComparatorFactory">
+		<constructor factoryClass="org.mobicents.protocols.ss7.sccp.impl.router.RuleComparatorFactory"
+					 factoryMethod="getInstance">
+			<parameter>RuleComparatorFactory</parameter>
+		</constructor>
+		<property name="ruleComparator">
+			<inject bean="RuleComparator"/>
+		</property>
+	</bean>
 
 </deployment>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 

--- a/service/wildfly/extension/pom.xml
+++ b/service/wildfly/extension/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.mobicents.protocols.ss7</groupId>
         <artifactId>restcomm-ss7-wildfly</artifactId>
-        <version>8.0.0-SNAPSHOT</version>
+        <version>8.0.107</version>
     </parent>
 
     <artifactId>restcomm-ss7-wildfly-extension</artifactId>

--- a/service/wildfly/modules/pom.xml
+++ b/service/wildfly/modules/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.mobicents.protocols.ss7</groupId>
         <artifactId>restcomm-ss7-wildfly</artifactId>
-        <version>8.0.0-SNAPSHOT</version>
+        <version>8.0.107</version>
     </parent>
 
     <artifactId>restcomm-ss7-wildfly-modules</artifactId>

--- a/service/wildfly/pom.xml
+++ b/service/wildfly/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.mobicents.protocols.ss7</groupId>
         <artifactId>restcomm-service-parent</artifactId>
-        <version>8.0.0-SNAPSHOT</version>
+        <version>8.0.107</version>
     </parent>
 
 	<artifactId>restcomm-ss7-wildfly</artifactId>

--- a/sgw/boot/pom.xml
+++ b/sgw/boot/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.sgw</groupId>
 		<artifactId>restcomm-sgw</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>boot</artifactId>

--- a/sgw/gateway/pom.xml
+++ b/sgw/gateway/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.sgw</groupId>
 		<artifactId>restcomm-sgw</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>gateway</artifactId>

--- a/sgw/pom.xml
+++ b/sgw/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<groupId>org.mobicents.protocols.ss7.sgw</groupId>

--- a/statistics/api/pom.xml
+++ b/statistics/api/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>statistics-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.statistics</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>statistics-api</artifactId>

--- a/statistics/impl/pom.xml
+++ b/statistics/impl/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>statistics-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.statistics</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>statistics-impl</artifactId>

--- a/statistics/pom.xml
+++ b/statistics/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<groupId>org.mobicents.protocols.ss7.statistics</groupId>

--- a/tcap-ansi/pom.xml
+++ b/tcap-ansi/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 

--- a/tcap-ansi/tcap-ansi-api/pom.xml
+++ b/tcap-ansi/tcap-ansi-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>tcap-ansi-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.tcapAnsi</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>tcap-ansi-api</artifactId>

--- a/tcap-ansi/tcap-ansi-cli/pom.xml
+++ b/tcap-ansi/tcap-ansi-cli/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>tcap-ansi-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.tcapAnsi</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>tcap-ansi-cli</artifactId>

--- a/tcap-ansi/tcap-ansi-impl/pom.xml
+++ b/tcap-ansi/tcap-ansi-impl/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>tcap-ansi-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.tcapAnsi</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>tcap-ansi-impl</artifactId>

--- a/tcap/pom.xml
+++ b/tcap/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 

--- a/tcap/tcap-api/pom.xml
+++ b/tcap/tcap-api/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>tcap-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.tcap</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>tcap-api</artifactId>

--- a/tcap/tcap-cli/pom.xml
+++ b/tcap/tcap-cli/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>tcap-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.tcap</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>tcap-cli</artifactId>

--- a/tcap/tcap-impl/pom.xml
+++ b/tcap/tcap-impl/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>tcap-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.tcap</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>tcap-impl</artifactId>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>ss7-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>tools</artifactId>

--- a/tools/simple-alarm-listener/alarmlistener/pom.xml
+++ b/tools/simple-alarm-listener/alarmlistener/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<groupId>org.mobicents.protocols.ss7.tools.alarmlistener</groupId>
 		<artifactId>alarm-listener-parent</artifactId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>alarm-listener</artifactId>

--- a/tools/simple-alarm-listener/pom.xml
+++ b/tools/simple-alarm-listener/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>tools</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
   <artifactId>alarm-listener-parent</artifactId>

--- a/tools/simulator/bootstrap/pom.xml
+++ b/tools/simulator/bootstrap/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>simulator-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.tools.simulator</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>simulator-bootstrap</artifactId>

--- a/tools/simulator/core/pom.xml
+++ b/tools/simulator/core/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>simulator-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.tools.simulator</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/tools/simulator/gui/pom.xml
+++ b/tools/simulator/gui/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>simulator-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.tools.simulator</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/tools/simulator/pom.xml
+++ b/tools/simulator/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>tools</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>simulator-parent</artifactId>

--- a/tools/trace-parser/bootstrap/pom.xml
+++ b/tools/trace-parser/bootstrap/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<artifactId>ss7-trace-parser-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.tools.traceparser</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
 	<artifactId>ss7-trace-parser-bootstrap</artifactId>

--- a/tools/trace-parser/parser/pom.xml
+++ b/tools/trace-parser/parser/pom.xml
@@ -2,7 +2,7 @@
 	<parent>
 		<artifactId>ss7-trace-parser-parent</artifactId>
 		<groupId>org.mobicents.protocols.ss7.tools.traceparser</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 	<modelVersion>4.0.0</modelVersion>
 

--- a/tools/trace-parser/pom.xml
+++ b/tools/trace-parser/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>tools</artifactId>
 		<groupId>org.mobicents.protocols.ss7</groupId>
-		<version>8.0.0-SNAPSHOT</version>
+		<version>8.0.107</version>
 	</parent>
 
   <artifactId>ss7-trace-parser-parent</artifactId>


### PR DESCRIPTION
The SCCP routing rules get quite complicated with multiple rules. The GUI already displays rules sorted by ID but it is not always clear to figure out which rule actually gets matched during SCCPRouting. Hence, it is much simpler to sort the rules based on ID and reduces the confusion.
