### PR TITLE
Issue-258: allow TCAP user specify ability to skip protocol version in dialogue portion

### DIFF
--- a/map/map-api/src/main/java/org/mobicents/protocols/ss7/map/api/MAPDialog.java
+++ b/map/map-api/src/main/java/org/mobicents/protocols/ss7/map/api/MAPDialog.java
@@ -140,6 +140,27 @@ public interface MAPDialog extends Serializable {
     void setNetworkId(int networkId);
 
     /**
+     * Option responsible for presence of the protocol version in 
+     * this dialogue portion.
+     * 
+     * @return boolean true if protocol version must be omitted, 
+     * false when it should be included and null if not defined at the 
+     * dialog level and global option should be used.
+     */
+    public Boolean isDoNotSendProtcolVersion();
+    
+    /**
+     * Modifies option responsible for presence of the protocol version in 
+     * this dialogue portion.
+     * 
+     * @param doNotSendProtocolVersion
+     * boolean true if protocol version must be omitted, 
+     * false when it should be included and null if not defined at the 
+     * dialog level and global option should be used.
+     */
+    public void setDoNotSendProtocolVersion(Boolean doNotSendProtocolVersion);
+    
+    /**
      * Remove MAPDialog without sending any messages and invoking events
      */
     void release();

--- a/map/map-impl/src/main/java/org/mobicents/protocols/ss7/map/MAPDialogImpl.java
+++ b/map/map-impl/src/main/java/org/mobicents/protocols/ss7/map/MAPDialogImpl.java
@@ -110,6 +110,16 @@ public abstract class MAPDialogImpl implements MAPDialog {
         return returnMessageOnError;
     }
 
+    @Override
+    public Boolean isDoNotSendProtcolVersion() {
+        return tcapDialog.isDoNotSendProtcolVersion();
+    }
+    
+    @Override
+    public void setDoNotSendProtocolVersion(Boolean doNotSendProtocolVersion) {
+        tcapDialog.setDoNotSendProtocolVersion(doNotSendProtocolVersion);
+    }
+    
     /**
      *
      * @return - local sccp address.

--- a/tcap/tcap-api/src/main/java/org/mobicents/protocols/ss7/tcap/api/tc/dialog/Dialog.java
+++ b/tcap/tcap-api/src/main/java/org/mobicents/protocols/ss7/tcap/api/tc/dialog/Dialog.java
@@ -129,6 +129,27 @@ public interface Dialog extends Serializable {
     void setNetworkId(int networkId);
 
     /**
+     * Option responsible for presence of the protocol version in 
+     * this dialogue portion.
+     * 
+     * @return boolean true if protocol version must be omitted, 
+     * false when it should be included and null if not defined at the 
+     * dialog level and global option should be used.
+     */
+    public Boolean isDoNotSendProtcolVersion();
+    
+    /**
+     * Modifies option responsible for presence of the protocol version in 
+     * this dialogue portion.
+     * 
+     * @param doNotSendProtocolVersion
+     * boolean true if protocol version must be omitted, 
+     * false when it should be included and null if not defined at the 
+     * dialog level and global option should be used.
+     */
+    public void setDoNotSendProtocolVersion(Boolean doNotSendProtocolVersion);
+    
+    /**
      * Cancels INVOKE pending to be sent. It is equivalent to TC-U-CANCEL.
      *
      * @return <ul>

--- a/tcap/tcap-impl/src/main/java/org/mobicents/protocols/ss7/tcap/DialogImpl.java
+++ b/tcap/tcap-impl/src/main/java/org/mobicents/protocols/ss7/tcap/DialogImpl.java
@@ -173,6 +173,8 @@ public class DialogImpl implements Dialog {
     private long startDialogTime;
     private int networkId;
 
+    private Boolean doNotSendProtocolVersion = null;
+    
     private static int getIndexFromInvokeId(Long l) {
         int tmp = l.intValue();
         return tmp + _INVOKE_TABLE_SHIFT;
@@ -269,6 +271,28 @@ public class DialogImpl implements Dialog {
         }
     }
 
+    @Override
+    public Boolean isDoNotSendProtcolVersion() {
+        return doNotSendProtocolVersion;
+    }
+    
+    @Override
+    public void setDoNotSendProtocolVersion(Boolean doNotSendProtocolVersion) {
+        this.doNotSendProtocolVersion = doNotSendProtocolVersion;
+    }
+    
+    /**
+     * Compute convergent option value as combination from dialog level value 
+     * and global value specified at stack level.
+     * 
+     * @return 
+     */
+    private boolean doNotSendProtocolVersion() {
+        return doNotSendProtocolVersion != null ? 
+                doNotSendProtocolVersion  :
+                provider.getStack().getDoNotSendProtocolVersion();
+    }
+    
     public void release() {
         if (!this.previewMode) {
             for (int i = 0; i < this.operationsSent.length; i++) {
@@ -539,7 +563,7 @@ public class DialogImpl implements Dialog {
                 DialogPortion dp = TcapFactory.createDialogPortion();
                 dp.setUnidirectional(false);
                 DialogRequestAPDU apdu = TcapFactory.createDialogAPDURequest();
-                apdu.setDoNotSendProtocolVersion(this.provider.getStack().getDoNotSendProtocolVersion());
+                apdu.setDoNotSendProtocolVersion(doNotSendProtocolVersion());
                 dp.setDialogAPDU(apdu);
                 apdu.setApplicationContextName(event.getApplicationContextName());
                 this.lastACN = event.getApplicationContextName();
@@ -618,7 +642,7 @@ public class DialogImpl implements Dialog {
                     DialogPortion dp = TcapFactory.createDialogPortion();
                     dp.setUnidirectional(false);
                     DialogResponseAPDU apdu = TcapFactory.createDialogAPDUResponse();
-                    apdu.setDoNotSendProtocolVersion(this.provider.getStack().getDoNotSendProtocolVersion());
+                    apdu.setDoNotSendProtocolVersion(doNotSendProtocolVersion());
                     dp.setDialogAPDU(apdu);
                     apdu.setApplicationContextName(event.getApplicationContextName());
                     if (event.getUserInformation() != null) {
@@ -751,7 +775,7 @@ public class DialogImpl implements Dialog {
                     DialogPortion dp = TcapFactory.createDialogPortion();
                     dp.setUnidirectional(false);
                     DialogResponseAPDU apdu = TcapFactory.createDialogAPDUResponse();
-                    apdu.setDoNotSendProtocolVersion(this.provider.getStack().getDoNotSendProtocolVersion());
+                    apdu.setDoNotSendProtocolVersion(doNotSendProtocolVersion());
                     dp.setDialogAPDU(apdu);
 
                     apdu.setApplicationContextName(event.getApplicationContextName());
@@ -853,7 +877,7 @@ public class DialogImpl implements Dialog {
             if (event.getApplicationContextName() != null) {
                 DialogPortion dp = TcapFactory.createDialogPortion();
                 DialogUniAPDU apdu = TcapFactory.createDialogAPDUUni();
-                apdu.setDoNotSendProtocolVersion(this.provider.getStack().getDoNotSendProtocolVersion());
+                apdu.setDoNotSendProtocolVersion(doNotSendProtocolVersion());
                 apdu.setApplicationContextName(event.getApplicationContextName());
                 if (event.getUserInformation() != null) {
                     apdu.setUserInformation(event.getUserInformation());
@@ -920,7 +944,7 @@ public class DialogImpl implements Dialog {
                         // Abnormal
                         // procedures on page 13 and 14
                         DialogResponseAPDU apdu = TcapFactory.createDialogAPDUResponse();
-                        apdu.setDoNotSendProtocolVersion(this.provider.getStack().getDoNotSendProtocolVersion());
+                        apdu.setDoNotSendProtocolVersion(doNotSendProtocolVersion());
                         apdu.setApplicationContextName(event.getApplicationContextName());
                         apdu.setUserInformation(event.getUserInformation());
 
@@ -1123,7 +1147,7 @@ public class DialogImpl implements Dialog {
             DialogPortion dp = TcapFactory.createDialogPortion();
             dp.setUnidirectional(false);
             DialogRequestAPDU apdu = TcapFactory.createDialogAPDURequest();
-            apdu.setDoNotSendProtocolVersion(this.provider.getStack().getDoNotSendProtocolVersion());
+            apdu.setDoNotSendProtocolVersion(doNotSendProtocolVersion());
             dp.setDialogAPDU(apdu);
             apdu.setApplicationContextName(event.getApplicationContextName());
             if (event.getUserInformation() != null) {
@@ -1164,7 +1188,7 @@ public class DialogImpl implements Dialog {
             DialogPortion dp = TcapFactory.createDialogPortion();
             dp.setUnidirectional(false);
             DialogResponseAPDU apdu = TcapFactory.createDialogAPDUResponse();
-            apdu.setDoNotSendProtocolVersion(this.provider.getStack().getDoNotSendProtocolVersion());
+            apdu.setDoNotSendProtocolVersion(doNotSendProtocolVersion());
             dp.setDialogAPDU(apdu);
             apdu.setApplicationContextName(event.getApplicationContextName());
             if (event.getUserInformation() != null) {
@@ -1230,7 +1254,7 @@ public class DialogImpl implements Dialog {
                 DialogPortion dp = TcapFactory.createDialogPortion();
                 dp.setUnidirectional(false);
                 DialogResponseAPDU apdu = TcapFactory.createDialogAPDUResponse();
-                apdu.setDoNotSendProtocolVersion(this.provider.getStack().getDoNotSendProtocolVersion());
+                apdu.setDoNotSendProtocolVersion(doNotSendProtocolVersion());
                 dp.setDialogAPDU(apdu);
 
                 apdu.setApplicationContextName(event.getApplicationContextName());
@@ -1270,7 +1294,7 @@ public class DialogImpl implements Dialog {
         if (event.getApplicationContextName() != null) {
             DialogPortion dp = TcapFactory.createDialogPortion();
             DialogUniAPDU apdu = TcapFactory.createDialogAPDUUni();
-            apdu.setDoNotSendProtocolVersion(this.provider.getStack().getDoNotSendProtocolVersion());
+            apdu.setDoNotSendProtocolVersion(doNotSendProtocolVersion());
             apdu.setApplicationContextName(event.getApplicationContextName());
             if (event.getUserInformation() != null) {
                 apdu.setUserInformation(event.getUserInformation());


### PR DESCRIPTION
This PR provides the following changes:
- new `Boolean` option `doNotSendProtocolVersion`  at the `TCAP` and `MAP` dialogs;
- final value is computed as combination of dialog's and stack's level values;
- by default at the dialog level this option has `null` value and stack level defines default value equal `false`.