### PR TITLE
Issue-291: NPE when TCAP dialogue portion w/o protocol version

### DIFF
--- a/tcap/tcap-impl/src/main/java/org/restcomm/protocols/ss7/tcap/TCAPProviderImpl.java
+++ b/tcap/tcap-impl/src/main/java/org/restcomm/protocols/ss7/tcap/TCAPProviderImpl.java
@@ -815,7 +815,7 @@ public class TCAPProviderImpl implements TCAPProvider, SccpListener {
                     if (tcb.getDialogPortion() != null && tcb.getDialogPortion().getDialogAPDU() != null
                             && tcb.getDialogPortion().getDialogAPDU() instanceof DialogRequestAPDUImpl) {
                         DialogRequestAPDUImpl dlg = (DialogRequestAPDUImpl) tcb.getDialogPortion().getDialogAPDU();
-                        if (!dlg.getProtocolVersion().isSupportedVersion()) {
+                        if (dlg.getProtocolVersion() != null && !dlg.getProtocolVersion().isSupportedVersion()) {
                             logger.error("Unsupported protocol version of  has been received when parsing TCBeginMessage");
                             this.sendProviderAbort(DialogServiceProviderType.NoCommonDialogPortion,
                                     tcb.getOriginatingTransactionId(), remoteAddress, localAddress, message.getSls(),


### PR DESCRIPTION
This PR provides fix for NPE during `protocolVersion` verification. If `protocolVersion` is not included into the dialogue portion the protocol version verification procedure is ignored.