### PR TITLE
Prevent a NullPointerException from being thrown when calling the toS…

### DIFF
--- a/map/map-impl/src/main/java/org/restcomm/protocols/ss7/map/primitives/MAPPrivateExtensionImpl.java
+++ b/map/map-impl/src/main/java/org/restcomm/protocols/ss7/map/primitives/MAPPrivateExtensionImpl.java
@@ -206,7 +206,7 @@ public class MAPPrivateExtensionImpl implements MAPPrivateExtension, MAPAsnPrimi
         StringBuilder sb = new StringBuilder();
         sb.append("PrivateExtension [");
 
-        if (this.oId != null || this.oId.length > 0) {
+        if (this.oId != null && this.oId.length > 0) {
             sb.append("Oid=");
             sb.append(this.ArrayToString(this.oId));
         }


### PR DESCRIPTION
The toString() method of the MAPPrivateExtensionImpl class may result in an NPE when the oId is not empty.
For example - when logging a MAPPrivateExtension object with a filled oId

```java
import org.restcomm.protocols.ss7.map.MAPParameterFactoryImpl;
import org.restcomm.protocols.ss7.map.api.MAPParameterFactory;
import org.restcomm.protocols.ss7.map.api.primitives.MAPPrivateExtension;

public class Main {
    public static void main(String[] args) {
        MAPParameterFactory map = new MAPParameterFactoryImpl();
        MAPPrivateExtension extension = map.createMAPPrivateExtension(new long[] {},null);
        System.out.println("1: Extension was created");
        System.out.println("1: " + extension);
        extension = map.createMAPPrivateExtension(null, new byte[] {});
        System.out.println("2: Extension was created");
        System.out.println("2: " + extension);
    }

}
```

```text
1: Extension was created
1: PrivateExtension [Oid=]
2: Extension was created
Exception in thread "main" java.lang.NullPointerException: Cannot read the array length because "this.oId" is null
	at org.restcomm.protocols.ss7.map.primitives.MAPPrivateExtensionImpl.toString(MAPPrivateExtensionImpl.java:209)
	at java.base/java.lang.String.valueOf(String.java:4465)
	at Main.main(Main.java:15)
```